### PR TITLE
Allow finer control of the debug level

### DIFF
--- a/src/d2d_log.f90
+++ b/src/d2d_log.f90
@@ -65,7 +65,8 @@ submodule (decomp_2d) d2d_log
 
     ! Basic info
 #ifdef DEBUG
-    if (decomp_debug > 1) write (io_unit, *) 'I am mpi rank ', nrank
+    if (decomp_debug >= D2D_DEBUG_LEVEL_INFO) &
+       write (io_unit, *) 'I am mpi rank ', nrank
 #endif
     write (io_unit, *) 'Total ranks ', nproc
     write (io_unit, *) 'Global data size : ', nx_global, ny_global, nz_global
@@ -140,7 +141,7 @@ submodule (decomp_2d) d2d_log
     !
     ! The system call, if writing to a file, is not blocking if supported
     !
-    if (nrank == 0 .or. decomp_debug > 1) then
+    if (nrank == 0 .or. decomp_debug >= D2D_DEBUG_LEVEL_INFO) then
        write (io_unit, *) '============== Environment variables ======================'
        write (io_unit, *) '==========================================================='
        write (io_unit, *) '==========================================================='

--- a/src/d2d_log.f90
+++ b/src/d2d_log.f90
@@ -65,7 +65,7 @@ submodule (decomp_2d) d2d_log
 
     ! Basic info
 #ifdef DEBUG
-    write (io_unit, *) 'I am mpi rank ', nrank
+    if (decomp_debug > 1) write (io_unit, *) 'I am mpi rank ', nrank
 #endif
     write (io_unit, *) 'Total ranks ', nproc
     write (io_unit, *) 'Global data size : ', nx_global, ny_global, nz_global
@@ -92,6 +92,7 @@ submodule (decomp_2d) d2d_log
     write (io_unit, '(" Version of the MPI library : ",I0,".",I0)') version, subversion
 #ifdef DEBUG
     write (io_unit, *) 'Compile flag DEBUG detected'
+    write (io_unit, *) '   debug level : ', decomp_debug
 #endif
 #ifdef SHM
     write (io_unit, *) 'Compile flag SHM detected'
@@ -135,9 +136,11 @@ submodule (decomp_2d) d2d_log
     !
     ! In DEBUG mode, rank 0 will also print environment variables
     !
+    ! At high debug level, all ranks will print env. variables
+    !
     ! The system call, if writing to a file, is not blocking if supported
     !
-    if (nrank == 0) then
+    if (nrank == 0 .or. decomp_debug > 1) then
        write (io_unit, *) '============== Environment variables ======================'
        write (io_unit, *) '==========================================================='
        write (io_unit, *) '==========================================================='

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -78,10 +78,19 @@ module decomp_2d
   !
   ! Debug checks are performed only when the preprocessor variable DEBUG is defined
   !
+  enum, bind(c)
+     enumerator :: D2D_DEBUG_LEVEL_OFF = 0
+     enumerator :: D2D_DEBUG_LEVEL_CRITICAL = 1
+     enumerator :: D2D_DEBUG_LEVEL_ERROR = 2
+     enumerator :: D2D_DEBUG_LEVEL_WARN = 3
+     enumerator :: D2D_DEBUG_LEVEL_INFO = 4
+     enumerator :: D2D_DEBUG_LEVEL_DEBUG = 5
+     enumerator :: D2D_DEBUG_LEVEL_TRACE = 6
+  end enum
 #ifdef DEBUG
-  integer, public, save :: decomp_debug = 1
+  integer(kind(D2D_DEBUG_LEVEL_OFF)), public, save :: decomp_debug = D2D_DEBUG_LEVEL_CRITICAL
 #else
-  integer, public, save :: decomp_debug = 0
+  integer(kind(D2D_DEBUG_LEVEL_OFF)), public, save :: decomp_debug = D2D_DEBUG_LEVEL_OFF
 #endif
 
 #if defined(_GPU)

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -88,7 +88,7 @@ module decomp_2d
      enumerator :: D2D_DEBUG_LEVEL_TRACE = 6
   end enum
 #ifdef DEBUG
-  integer(kind(D2D_DEBUG_LEVEL_OFF)), public, save :: decomp_debug = D2D_DEBUG_LEVEL_CRITICAL
+  integer(kind(D2D_DEBUG_LEVEL_OFF)), public, save :: decomp_debug = D2D_DEBUG_LEVEL_INFO
 #else
   integer(kind(D2D_DEBUG_LEVEL_OFF)), public, save :: decomp_debug = D2D_DEBUG_LEVEL_OFF
 #endif


### PR DESCRIPTION
When the DEBUG preprocessor variable is defined, the debug level can be changed

- From the external code, with a modification of the variable `decomp_debug` before calling `decomp_2d_init`
- Using the environment variable `DECOMP_2D_DEBUG`

If both strategies are employed, the environment variable is taken into account.

This PR can fix https://github.com/xcompact3d/2decomp-fft/issues/34