### PR TITLE
Fix compiler warnings in restore io branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,20 @@ else ifeq ($(FFT),cufft)
   #LIBFFT=-L$(CUFFT_PATH)/lib64 -Mcudalib=cufft 
 endif
 
+### IO Options ###
+LIBIO :=
+OPTIO :=
+INCIO :=
+ADIOS2DIR :=
+ifeq ($(IO),adios2)
+  ifeq ($(ADIOS2DIR),)
+    $(error Set ADIOS2DIR=/path/to/adios2/install/)
+  endif
+  OPTIO := -DADIOS2 $(OPT)
+  INCIO := $(INC) $(shell $(ADIOS2DIR)/bin/adios2-config --fortran-flags) #$(patsubst $(shell $(ADIOS2DIR)/bin/adios2-config --fortran-libs),,$(shell $(ADIOS2DIR)/bin/adios2-config -f))
+  LIBIO := $(shell $(ADIOS2DIR)/bin/adios2-config --fortran-libs)
+endif
+
 SRCDECOMP := $(SRCDECOMP) fft_$(FFT).f90
 SRCDECOMP_ = $(patsubst %.f90,$(SRCDIR)/%.f90,$(SRCDECOMP))
 OBJDECOMP = $(SRCDECOMP_:$(SRCDIR)/%.f90=$(OBJDIR)/%.o)
@@ -73,6 +87,9 @@ OBJDIR = obj
 SRCDIR = src
 DECOMPINC = mod
 FFLAGS += $(MODFLAG)$(DECOMPINC) -I$(DECOMPINC)
+
+OPT += $(OPTIO)
+INC += $(INCIO)
 
 all: $(DECOMPINC) $(OBJDIR) $(LIBDECOMP)
 

--- a/src/io_read_inflow.f90
+++ b/src/io_read_inflow.f90
@@ -62,6 +62,10 @@ associate(fh=>fh_registry(idx), &
      disp = disp + sizes(1)*sizes(2)*sizes(3)*mytype_bytes
   end if
 end associate
+
+associate(vnm => varname) ! Silence unused argument
+end associate
+
 #else
 !! Use ADIOS2
 call adios2_at_io(io_handle, adios, io_name, ierror)

--- a/src/io_write_one.inc
+++ b/src/io_write_one.inc
@@ -57,6 +57,9 @@ gs = ceiling(real(sizes(1),mytype)*real(sizes(2),mytype)* &
      real(sizes(3),mytype)/1024./1024.)
 call t3pio_set_info(MPI_COMM_WORLD, info, "./", ierror, &
      GLOBAL_SIZE=gs, factor=1)
+#else
+gs = 1 ! Silence unused variable
+info = 1 ! Silence unused variable
 #endif
 
 call MPI_TYPE_CREATE_SUBARRAY(3, sizes, subsizes, starts,  &

--- a/src/io_write_outflow.f90
+++ b/src/io_write_outflow.f90
@@ -62,6 +62,10 @@ associate(fh=>fh_registry(idx), &
      disp = disp + sizes(1)*sizes(2)*sizes(3)*mytype_bytes
   end if
 end associate
+
+associate(vnm => varname) ! Silence unused dummy argument
+end associate
+
 #else
 !! Use ADIOS2
 call adios2_at_io(io_handle, adios, io_name, ierror)


### PR DESCRIPTION
Mostly this is where a subroutine has an argument that is used by
ADIOS2 but not MPIIO or vice-versa.
Also discovered some unused variables