### PR TITLE
Fix examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@
 
 # Cmake
 build
+
+# Log files
+*.log
+
+Makefile.settings

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ FCFLAGS ?= # user can set default compiler flags
 LDFLAGS ?= # user can set default linker flags
 FFLAGS = $(FCFLAGS)
 LFLAGS = $(LDFLAGS)
-MODFLAG = -J
+MODFLAG = -J 
 
 LIBDECOMP = decomp2d
 
@@ -74,12 +74,14 @@ SRCDIR = src
 DECOMPINC = mod
 FFLAGS += $(MODFLAG)$(DECOMPINC) -I$(DECOMPINC)
 
+include Makefile.settings
+
 all: $(DECOMPINC) $(OBJDIR) $(LIBDECOMP)
 
 $(DECOMPINC):
 	mkdir $(DECOMPINC)
 
-$(LIBDECOMP) : lib$(LIBDECOMP).a
+$(LIBDECOMP) : Makefile.settings lib$(LIBDECOMP).a
 
 lib$(LIBDECOMP).a: $(OBJDECOMP)
 	$(AR) $(LIBOPT) $@ $^
@@ -93,13 +95,29 @@ $(OBJDECOMP) : $(OBJDIR)/%.o : $(SRCDIR)/%.f90
 examples: $(LIBDECOMP)
 	$(MAKE) -C examples
 
+.PHONY: check
+
+check: examples
+	$(MAKE) -C examples $@
+
 .PHONY: clean
 
 clean: clean-examples
 	rm -f $(OBJDIR)/*.o $(DECOMPINC)/*.mod $(DECOMPINC)/*.smod lib$(LIBDECOMP).a
 	rm -f ./*.o ./*.mod ./*.smod # Ensure old files are removed
+	rm -f Makefile.settings
 
 clean-examples:
 	$(MAKE) -C examples clean
+
+.PHONY: Makefile.settings
+
+Makefile.settings:
+	echo "FFLAGS = $(FFLAGS)" > $@
+	echo "OPT = $(OPT)" >> $@
+	echo "DEFS = $(DEFS)" >> $@
+	echo "INC = $(INC)" >> $@
+	echo "LIBOPT = $(LIBOPT)" >> $@
+	echo "LIBFFT = ${LIBFFT}" >> $@
 
 export

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 2decomp-fft
 
+## Building
+
 Different compilers can be set by specifying `CMP`, e.g. `make CMP=intel`
 to build with Intel compilers, see `Makefile` for options.
 
@@ -7,6 +9,14 @@ By default an optimised library will be built, debugging versions of the
 library can be built with `make BUILD=debug`, a development version which 
 additionally sets compile time flags to catch coding errors can be built 
 with `make BUILD=dev` (GNU compilers only currently).
+
+On each build of the library (`make`, `make all`) a temporary file `Makefile.settings` with
+all current options (`FFLAGS`, `DEFS`, etc.) will be created, and included
+on subsequent invocations, the user therefore does not need to keep
+specifying options between builds.
+
+To perform a clean build run `make clean` first, this will delete all
+output files, including `Makefile.settings`.
 
 ## Testing and examples
 
@@ -17,5 +27,4 @@ make examples
 ```
 which will (re)build 2decomp&fft as necessary.
 
-**TODO** Test running the examples
 **TODO** Convert examples to tests and automate running them

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,0 +1,1 @@
+decomp_2d_setup_*.log

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -17,19 +17,10 @@ halo_test:
 io_test:
 	$(MAKE) -C $@ all
 
-# test all the examples (individual Makefiles should take care of updating)
-basic_test:
-	cd test2d; $(MAKE) $@
-	cd fft_test_c2c; $(MAKE) $@
-	cd fft_test_r2c; $(MAKE) $@
-	cd timing; $(MAKE) $@
-	cd halo_test; $(MAKE) $@
-	cd io_test; $(MAKE) $@
-
 check:
 	cd test2d; $(MAKE) $@
 	cd fft_test_c2c; $(MAKE) $@
-	#cd fft_test_r2c; $(MAKE) $@
+	cd fft_test_r2c; $(MAKE) $@
 	cd timing; $(MAKE) $@
 	cd halo_test; $(MAKE) $@
 	#cd io_test; $(MAKE) $@

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -26,6 +26,14 @@ basic_test:
 	cd halo_test; $(MAKE) $@
 	cd io_test; $(MAKE) $@
 
+check:
+	cd test2d; $(MAKE) $@
+	cd fft_test_c2c; $(MAKE) $@
+	#cd fft_test_r2c; $(MAKE) $@
+	cd timing; $(MAKE) $@
+	cd halo_test; $(MAKE) $@
+	#cd io_test; $(MAKE) $@
+
 clean:
 	cd test2d; $(MAKE) $@
 	cd fft_test_c2c; $(MAKE) $@
@@ -33,3 +41,5 @@ clean:
 	cd timing; $(MAKE) $@
 	cd halo_test; $(MAKE) $@
 	cd io_test; $(MAKE) $@
+
+export

--- a/examples/fft_test_c2c/Makefile
+++ b/examples/fft_test_c2c/Makefile
@@ -1,17 +1,23 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT)
 
 OBJ = fft_test_c2c.o
 
+MPIRUN ?= mpirun
+NP ?= 1
+
 fft_test_c2c: $(OBJ)
-	$(FC) -o $@ $(OBJ) $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
+
+check:
+	$(MPIRUN) -n $(NP) ./fft_test_c2c
 
 clean:
 	rm -f *.o fft_test_c2c
 
 %.o : %.f90
-	$(FC) $(INC) $(OPTIONS) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $^ -o $@

--- a/examples/fft_test_c2c/Makefile
+++ b/examples/fft_test_c2c/Makefile
@@ -17,7 +17,7 @@ check:
 	$(MPIRUN) -n $(NP) ./fft_test_c2c
 
 clean:
-	rm -f *.o fft_test_c2c
+	rm -f *.o fft_test_c2c *.log
 
 %.o : %.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $^ -o $@

--- a/examples/fft_test_c2c/fft_test_c2c.f90
+++ b/examples/fft_test_c2c/fft_test_c2c.f90
@@ -13,14 +13,18 @@ use decomp_2d_fft
 implicit none
 
 integer, parameter :: nx=2, ny=3, nz=4
-integer :: p_row=2, p_col=2
+integer :: p_row=0, p_col=0
 
 complex(mytype), allocatable, dimension(:,:,:) :: in, out
 
 complex(mytype), dimension(nx,ny,nz) :: in1, out1
 integer :: ierror, i,j,k
+logical :: error_flag
 
+! Init
+error_flag = .false.
 call MPI_INIT(ierror)
+if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
 call decomp_2d_init(nx,ny,nz,p_row,p_col)
 call decomp_2d_fft_init
 
@@ -71,6 +75,7 @@ do k=xstart(3),xend(3)
 end do
 
 ! write out input, to match the format of NAG example result file
+#ifdef DEBUG
 if (nrank==0) then
    write(*,*) 'C06FXF Example Program Results'
    write(*,*) ''
@@ -78,6 +83,7 @@ if (nrank==0) then
    write(*,*) ''
    call print_global(in1,nx,ny,nz)
 end if
+#endif
 
 ! ===== 3D forward FFT =====
 call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
@@ -94,11 +100,13 @@ end do
 call assemble_global(3,out,out1,nx,ny,nz)
 
 ! write out forward FFT result
+#ifdef DEBUG
 if (nrank==0) then
    write(*,*) 'Components of discrete Fourier transform'
    write(*,*) ''
    call print_global(out1,nx,ny,nz)
 end if
+#endif
 
 ! ===== 3D inverse FFT =====
 call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
@@ -115,11 +123,13 @@ end do
 call assemble_global(1,in,in1,nx,ny,nz)
 
 ! write out inverse FFT result
+#ifdef DEBUG
 if (nrank==0) then
    write(*,*) 'Original sequence as restored by inverse transform'
    write(*,*) ''
    call print_global(in1,nx,ny,nz)
 end if
+#endif
 
 call decomp_2d_fft_finalize
 call decomp_2d_finalize

--- a/examples/fft_test_c2c/fft_test_c2c.f90
+++ b/examples/fft_test_c2c/fft_test_c2c.f90
@@ -218,12 +218,12 @@ subroutine assemble_global(ndir,local,global,nx,ny,nz)
      do m=1,nproc-1
         CALL MPI_RECV(rbuf1,9,MPI_INTEGER,m,m,MPI_COMM_WORLD, &
              status,ierror)
-        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
+        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_RECV")
         allocate(rbuf(rbuf1(1):rbuf1(2),rbuf1(4):rbuf1(5), &
              rbuf1(7):rbuf1(8)))
         CALL MPI_RECV(rbuf,rbuf1(3)*rbuf1(6)*rbuf1(9),complex_type,m, &
              m+nproc,MPI_COMM_WORLD,status,ierror)
-        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
+        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_RECV")
         do k=rbuf1(7),rbuf1(8)
            do j=rbuf1(4),rbuf1(5)
               do i=rbuf1(1),rbuf1(2)
@@ -260,11 +260,11 @@ subroutine assemble_global(ndir,local,global,nx,ny,nz)
      end if
      ! send partition information
      CALL MPI_SEND(sbuf1,9,MPI_INTEGER,0,nrank,MPI_COMM_WORLD,ierror)
-     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_SEND")
      ! send data array
      CALL MPI_SEND(local,count,complex_type,0, &
           nrank+nproc,MPI_COMM_WORLD,ierror)
-     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_SEND")
   end if
   
   return

--- a/examples/fft_test_c2c/fft_test_c2c.f90
+++ b/examples/fft_test_c2c/fft_test_c2c.f90
@@ -115,7 +115,7 @@ call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
 do k=xstart(3),xend(3)
    do j=xstart(2),xend(2)
       do i=xstart(1),xend(1)
-         in(i,j,k) = in(i,j,k) / sqrt(real(nx*ny*nz))
+         in(i,j,k) = in(i,j,k) / sqrt(real(nx*ny*nz,kind=mytype))
       end do
    end do
 end do
@@ -135,7 +135,7 @@ end if
 do k=xstart(3),xend(3)
    do j=xstart(2),xend(2)
       do i=xstart(1),xend(1)
-         if (abs(in(i,j,k)-in1(i,j,k))>10*epsilon(real(in(1,1,1)))) error_flag = .true.
+         if (abs(in(i,j,k)-in1(i,j,k))>100*epsilon(real(in(1,1,1)))) error_flag = .true.
       end do
    end do
 end do
@@ -153,6 +153,12 @@ endif
 call MPI_ALLREDUCE(MPI_IN_PLACE, error_flag, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
 if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
 if (error_flag) call decomp_2d_abort(1, "error in fft_c2c")
+
+if (nrank == 0) then
+   write(*,*) " "
+   write(*,*) " fft_test_c2c completed"
+   write(*,*) " "
+endif
 
 call decomp_2d_fft_finalize
 call decomp_2d_finalize

--- a/examples/fft_test_c2c/fft_test_c2c.f90
+++ b/examples/fft_test_c2c/fft_test_c2c.f90
@@ -189,10 +189,12 @@ subroutine assemble_global(ndir,local,global,nx,ny,nz)
      do m=1,nproc-1
         CALL MPI_RECV(rbuf1,9,MPI_INTEGER,m,m,MPI_COMM_WORLD, &
              status,ierror)
+        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
         allocate(rbuf(rbuf1(1):rbuf1(2),rbuf1(4):rbuf1(5), &
              rbuf1(7):rbuf1(8)))
         CALL MPI_RECV(rbuf,rbuf1(3)*rbuf1(6)*rbuf1(9),complex_type,m, &
              m+nproc,MPI_COMM_WORLD,status,ierror)
+        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
         do k=rbuf1(7),rbuf1(8)
            do j=rbuf1(4),rbuf1(5)
               do i=rbuf1(1),rbuf1(2)
@@ -229,9 +231,11 @@ subroutine assemble_global(ndir,local,global,nx,ny,nz)
      end if
      ! send partition information
      CALL MPI_SEND(sbuf1,9,MPI_INTEGER,0,nrank,MPI_COMM_WORLD,ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
      ! send data array
      CALL MPI_SEND(local,count,complex_type,0, &
           nrank+nproc,MPI_COMM_WORLD,ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_INIT")
   end if
   
   return

--- a/examples/fft_test_c2c/fft_test_c2c.f90
+++ b/examples/fft_test_c2c/fft_test_c2c.f90
@@ -92,7 +92,7 @@ call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
 do k=zstart(3),zend(3)
    do j=zstart(2),zend(2)
       do i=zstart(1),zend(1)
-         out(i,j,k) = out(i,j,k) / sqrt(real(nx*ny*nz))
+         out(i,j,k) = out(i,j,k) / sqrt(real(nx*ny*nz,kind=mytype))
       end do
    end do
 end do

--- a/examples/fft_test_r2c/Makefile
+++ b/examples/fft_test_r2c/Makefile
@@ -17,7 +17,7 @@ check:
 	$(MPIRUN) -n $(NP) ./fft_test_r2c
 
 clean:
-	rm -f *.o fft_test_r2c
+	rm -f *.o fft_test_r2c *.log
 
 %.o : %.f90
 	$(FC) $(INCLUDE) $(OPTIONS) $(FFLAGS) -c $<

--- a/examples/fft_test_r2c/Makefile
+++ b/examples/fft_test_r2c/Makefile
@@ -11,7 +11,7 @@ NP ?= 1
 MPIRUN ?= mpirun
 
 fft_test_r2c: $(OBJ)
-	$(FC) -o $@ $(OBJ) $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
 
 check:
 	$(MPIRUN) -n $(NP) ./fft_test_r2c
@@ -20,4 +20,4 @@ clean:
 	rm -f *.o fft_test_r2c *.log
 
 %.o : %.f90
-	$(FC) $(INCLUDE) $(OPTIONS) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/fft_test_r2c/Makefile
+++ b/examples/fft_test_r2c/Makefile
@@ -1,14 +1,20 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT)
 
 OBJ = fft_test_r2c.o
 
+NP ?= 1
+MPIRUN ?= mpirun
+
 fft_test_r2c: $(OBJ)
 	$(FC) -o $@ $(OBJ) $(LIBS)
+
+check:
+	$(MPIRUN) -n $(NP) ./fft_test_r2c
 
 clean:
 	rm -f *.o fft_test_r2c

--- a/examples/fft_test_r2c/fft_test_r2c.f90
+++ b/examples/fft_test_r2c/fft_test_r2c.f90
@@ -16,7 +16,7 @@ program fft_test_r2c
   !include "fftw3.f"
   
   integer, parameter :: nx=4, ny=2, nz=3
-  integer :: p_row=2, p_col=2
+  integer :: p_row=0, p_col=0
   
   real(mytype), allocatable, dimension(:,:,:) :: in, in2
   complex(mytype), allocatable, dimension(:,:,:) :: out
@@ -33,6 +33,8 @@ program fft_test_r2c
   integer :: fh, ierror, i,j,k, n,iol
   
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
   call decomp_2d_fft_init
   

--- a/examples/halo_test/Makefile
+++ b/examples/halo_test/Makefile
@@ -1,17 +1,23 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP)
 
 OBJ = halo_test.o
 
+NP ?= 1
+MPIRUN ?= mpirun
+
 halo_test: $(OBJ)
-	$(FC) -o $@ $(OBJ) $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
+
+check:
+	$(MPIRUN) -n $(NP) ./halo_test
 
 clean:
 	rm -f *.o halo_test
 
 %.o : %.f90
-	$(FC) $(INCLUDE) $(OPTIONS) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/halo_test/Makefile
+++ b/examples/halo_test/Makefile
@@ -17,7 +17,7 @@ check:
 	$(MPIRUN) -n $(NP) ./halo_test
 
 clean:
-	rm -f *.o halo_test
+	rm -f *.o halo_test *.log
 
 %.o : %.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/io_test/Makefile
+++ b/examples/io_test/Makefile
@@ -1,7 +1,7 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP)
 ifneq (,$(findstring DT3PIO,$(OPTIONS)))
@@ -24,6 +24,13 @@ io_plane_test: io_plane_test.o
 
 io_bench: io_bench.o
 	$(FC) -o $@ $@.o $(LIBS)
+
+check:
+	mpirun -n 12 ./io_test
+	mpirun -n 6 ./io_read
+	mpirun -n 6 ./io_var_test 3 2
+	mpirun -n 12 ./io_plane_test
+	mpirun -n 16 ./io_bench
 
 clean:
 	rm -f *.o io_test io_read io_var_test io_plane_test io_bench

--- a/examples/io_test/Makefile
+++ b/examples/io_test/Makefile
@@ -36,7 +36,7 @@ clean:
 	rm -f *.o io_test io_read io_var_test io_plane_test io_bench
 
 realclean: clean
-	rm -f *.dat io_var_data.*
+	rm -f *.dat io_var_data.* *.log
 
 %.o : %.f90
 	$(FC) $(INCLUDE) $(OPTIONS) $(ARG) $(FFLAGS) -c $<

--- a/examples/io_test/Makefile
+++ b/examples/io_test/Makefile
@@ -4,26 +4,23 @@
 FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP)
-ifneq (,$(findstring DT3PIO,$(OPTIONS)))
-  LIBS+= -L$(T3PIO_PATH)/lib -lt3pio
-endif
 
 all: io_test io_read io_var_test io_plane_test io_bench
 
 io_test: io_test.o
-	$(FC) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 io_read: io_read.o
-	$(FC) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 io_var_test: io_var_test.o
-	$(FC) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 io_plane_test: io_plane_test.o
-	$(FC) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 io_bench: io_bench.o
-	$(FC) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 check:
 	mpirun -n 12 ./io_test
@@ -39,4 +36,4 @@ realclean: clean
 	rm -f *.dat io_var_data.* *.log
 
 %.o : %.f90
-	$(FC) $(INCLUDE) $(OPTIONS) $(ARG) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/io_test/io_bench.f90
+++ b/examples/io_test/io_bench.f90
@@ -15,6 +15,8 @@ program io_bench
   integer :: ierror
 
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
 
   allocate(u1(xstart(1):xend(1), xstart(2):xend(2), xstart(3):xend(3)))

--- a/examples/io_test/io_plane_test.f90
+++ b/examples/io_test/io_plane_test.f90
@@ -18,6 +18,8 @@ program io_plane_test
   integer :: i,j,k, m, ierror, iol
 
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
   
   ! ***** global data *****

--- a/examples/io_test/io_read.f90
+++ b/examples/io_test/io_read.f90
@@ -26,6 +26,8 @@ program io_read
   integer :: i,j,k, m, ierror
   
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
 
   ! ***** global data *****

--- a/examples/io_test/io_test.f90
+++ b/examples/io_test/io_test.f90
@@ -27,6 +27,8 @@ program io_test
   integer :: i,j,k, m, ierror
   
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
 
   ! ***** global data *****

--- a/examples/io_test/io_var_test.f90
+++ b/examples/io_test/io_var_test.f90
@@ -40,6 +40,8 @@ program io_var_test
   integer (kind=MPI_OFFSET_KIND) :: filesize, disp
 
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
 
   i = command_argument_count()
   if (i/=2) then

--- a/examples/non_blocking/Makefile
+++ b/examples/non_blocking/Makefile
@@ -6,13 +6,13 @@ LIBS = -L../../lib -l2decomp_fft $(LIBFFT)
 all: blocking non_blocking
 
 blocking: blocking.o
-	$(F90) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
 
 non_blocking: non_blocking.o
-	$(F90) -o $@ $@.o $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
 
 clean:
 	rm -f *.o blocking non_blocking
 
 %.o : %.f90
-	$(F90) $(INCLUDE) $(OPTIONS) $(F90FLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/test2d/Makefile
+++ b/examples/test2d/Makefile
@@ -17,7 +17,7 @@ check:
 	$(MPIRUN) -n $(NP) ./test2d
 
 clean:
-	rm -f *.o test2d u*.dat
+	rm -f *.o test2d u*.dat *.log
 
 %.o : %.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/test2d/Makefile
+++ b/examples/test2d/Makefile
@@ -1,17 +1,23 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP)
 
 OBJ = test2d.o
 
+NP ?= 1
+MPIRUN ?= mpirun
+
 test2d: $(OBJ)
-	$(FC) -o $@ $(OBJ) $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
+
+check:
+	$(MPIRUN) -n $(NP) ./test2d
 
 clean:
 	rm -f *.o test2d u*.dat
 
 %.o : %.f90
-	$(FC) $(INC) $(OPTIONS) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/test2d/test2d.f90
+++ b/examples/test2d/test2d.f90
@@ -8,15 +8,19 @@ program test2d
   implicit none
 
   integer, parameter :: nx=17, ny=13, nz=11
-  integer :: p_row=4, p_col=3
+  integer :: p_row=0, p_col=0
 
   real(mytype), dimension(nx,ny,nz) :: data1
   
   real(mytype), allocatable, dimension(:,:,:) :: u1, u2, u3
   
   integer :: i,j,k, m, ierror
-  
+  logical :: error_flag
+
+  ! Init
+  error_flag = .false.
   call MPI_INIT(ierror)
+  if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_INIT")
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
 
   ! ***** global data *****
@@ -52,12 +56,14 @@ program test2d
 
 10 format(15I5)
 
+#ifdef DEBUG
   if (nrank==0) then 
      write(*,*) 'Numbers held on Rank 0'
      write(*,*) ' '
      write(*,*) 'X-pencil'
      write(*,10) int(u1)
   end if
+#endif
 
   ! call decomp_2d_write_one(1,u1,'u1.dat')
 
@@ -65,11 +71,13 @@ program test2d
   ! x-pensil ==> y-pensil
   call transpose_x_to_y(u1,u2)
 
+#ifdef DEBUG
   if (nrank==0) then
      write(*,*) ' '
      write(*,*) 'Y-pencil'
      write(*,10) int(u2)
   end if
+#endif
 
   ! call decomp_2d_write_one(2,u2,'u2.dat')
   ! 'u1.dat' and 'u2.dat' should be identical byte-by-byte 
@@ -78,20 +86,25 @@ program test2d
   do k=ystart(3),yend(3)
     do j=ystart(2),yend(2)
       do i=ystart(1),yend(1)
-        if (abs(u2(i,j,k)-data1(i,j,k)).gt.0) stop "error swaping x->y"
+        if (abs(u2(i,j,k)-data1(i,j,k)).gt.0) error_flag = .true.
       end do
     end do
   end do
+  call MPI_ALLREDUCE(MPI_IN_PLACE, error_flag, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
+  if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
+  if (error_flag) call decomp_2d_abort(1, "error swaping x->y")
 
   !!!!!!!!!!!!!!!!!!!!!!!
   ! y-pensil ==> z-pensil
   call transpose_y_to_z(u2,u3)
 
+#ifdef DEBUG
   if (nrank==0) then
      write(*,*) ' '
      write(*,*) 'Z-pencil'
      write(*,10) int(u3)
   end if
+#endif
 
   ! call decomp_2d_write_one(3,u3,'u3.dat')
   ! 'u1.dat','u2.dat' and 'u3.dat' should be identical
@@ -99,10 +112,13 @@ program test2d
   do k=zstart(3),zend(3)
     do j=zstart(2),zend(2)
       do i=zstart(1),zend(1)
-        if (abs(u3(i,j,k)-data1(i,j,k)).gt.0) stop "error swaping y->z"
+        if (abs(u3(i,j,k)-data1(i,j,k)).gt.0) error_flag = .true.
       end do
     end do
   end do
+  call MPI_ALLREDUCE(MPI_IN_PLACE, error_flag, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
+  if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
+  if (error_flag) call decomp_2d_abort(2, "error swaping y->z")
 
   !!!!!!!!!!!!!!!!!!!!!!!
   ! z-pensil ==> y-pensil
@@ -112,10 +128,13 @@ program test2d
   do k=ystart(3),yend(3)
     do j=ystart(2),yend(2)
       do i=ystart(1),yend(1)
-        if (abs(u2(i,j,k)-data1(i,j,k)).gt.0) stop "error swaping z->y"
+        if (abs(u2(i,j,k)-data1(i,j,k)).gt.0) error_flag = .true.
       end do
     end do
   end do
+  call MPI_ALLREDUCE(MPI_IN_PLACE, error_flag, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
+  if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
+  if (error_flag) call decomp_2d_abort(3, "error swaping z->y")
 
   !!!!!!!!!!!!!!!!!!!!!!!
   ! y-pensil ==> x-pensil
@@ -125,10 +144,19 @@ program test2d
   do k=xstart(3),xend(3)
     do j=xstart(2),xend(2)
       do i=xstart(1),xend(1)
-        if (abs(u1(i,j,k)-data1(i,j,k)).gt.0) stop "error swaping y->x"
+        if (abs(u1(i,j,k)-data1(i,j,k)).gt.0) error_flag = .true.
       end do
     end do
   end do
+  call MPI_ALLREDUCE(MPI_IN_PLACE, error_flag, 1, MPI_LOGICAL, MPI_LOR, MPI_COMM_WORLD, ierror)
+  if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
+  if (error_flag) call decomp_2d_abort(4, "error swaping y->x")
+
+  if (nrank == 0) then
+    write(*,*) " "
+    write(*,*) "test2d completed"
+    write(*,*) " "
+  endif
 
   call decomp_2d_finalize 
   call MPI_FINALIZE(ierror)

--- a/examples/timing/Makefile
+++ b/examples/timing/Makefile
@@ -8,7 +8,7 @@ LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT)
 OBJ = timing.o
 
 timing: $(OBJ)
-	$(FC) -o $@ $(OBJ) $(LIBS)
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
 
 check:
 	mpirun -n 4 ./timing
@@ -20,4 +20,4 @@ clean:
 	rm -f *.o timing *.log
 
 %.o : %.f90
-	$(FC) $(INCLUDE) $(OPTIONS) $(FFLAGS) -c $<
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/timing/Makefile
+++ b/examples/timing/Makefile
@@ -17,7 +17,7 @@ mem_leak:
 	valgrind --leak-check=full --show-leak-kinds=all mpirun -n 1 ./timing 1 1
 
 clean:
-	rm -f *.o timing
+	rm -f *.o timing *.log
 
 %.o : %.f90
 	$(FC) $(INCLUDE) $(OPTIONS) $(FFLAGS) -c $<

--- a/examples/timing/Makefile
+++ b/examples/timing/Makefile
@@ -1,7 +1,7 @@
 #include ../../src/Makefile.inc
 
 #INCLUDE = -I../../include
-FFLAGS := $(patsubst -J%,-J../../%,$(FFLAGS))
+FFLAGS := $(patsubst -J\ %,-J\ ../../%,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT)
 
@@ -9,6 +9,12 @@ OBJ = timing.o
 
 timing: $(OBJ)
 	$(FC) -o $@ $(OBJ) $(LIBS)
+
+check:
+	mpirun -n 4 ./timing
+
+mem_leak:
+	valgrind --leak-check=full --show-leak-kinds=all mpirun -n 1 ./timing 1 1
 
 clean:
 	rm -f *.o timing

--- a/examples/timing/timing.f90
+++ b/examples/timing/timing.f90
@@ -21,6 +21,8 @@ program fft_timing
   double precision :: t1, t2, t3 ,t4
   
   call MPI_INIT(ierror)
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nproc, ierror)
+  call MPI_COMM_RANK(MPI_COMM_WORLD, nrank, ierror)
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
 
 

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -524,24 +524,11 @@ contains
     
     implicit none
  
-    integer :: ierror
-
-    call MPI_COMM_FREE(DECOMP_2D_COMM_ROW, ierror)
-    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
-    call MPI_COMM_FREE(DECOMP_2D_COMM_COL, ierror)
-    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
-    call MPI_COMM_FREE(DECOMP_2D_COMM_CART_X, ierror)
-    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
-    call MPI_COMM_FREE(DECOMP_2D_COMM_CART_Y, ierror)
-    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
-    call MPI_COMM_FREE(DECOMP_2D_COMM_CART_Z, ierror)
-    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
-
-    DECOMP_2D_COMM_ROW = MPI_COMM_NULL
-    DECOMP_2D_COMM_COL = MPI_COMM_NULL
-    DECOMP_2D_COMM_CART_X = MPI_COMM_NULL
-    DECOMP_2D_COMM_CART_Y = MPI_COMM_NULL
-    DECOMP_2D_COMM_CART_Z = MPI_COMM_NULL
+    call decomp_mpi_comm_free(DECOMP_2D_COMM_ROW)
+    call decomp_mpi_comm_free(DECOMP_2D_COMM_COL)
+    call decomp_mpi_comm_free(DECOMP_2D_COMM_CART_X)
+    call decomp_mpi_comm_free(DECOMP_2D_COMM_CART_Y)
+    call decomp_mpi_comm_free(DECOMP_2D_COMM_CART_Z)
 
     call decomp_info_finalize(decomp_main)
 
@@ -558,6 +545,25 @@ contains
     return
   end subroutine decomp_2d_finalize
 
+  !
+  ! Small wrapper to free a MPI communicator
+  !
+  subroutine decomp_mpi_comm_free(mpi_comm)
+
+    implicit none
+
+    integer, intent(inout) :: mpi_comm
+    integer :: ierror
+
+    ! Return if no MPI comm to free
+    if (mpi_comm == MPI_COMM_NULL) return
+
+    ! Free the provided MPI communicator
+    call MPI_COMM_FREE(mpi_comm, ierror)
+    if (ierror /= 0) call decomp_2d_warning(__FILE__, __LINE__, ierror, "MPI_COMM_FREE")
+    mpi_comm = MPI_COMM_NULL
+
+  end subroutine decomp_mpi_comm_free
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Return the default decomposition object

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -542,6 +542,9 @@ contains
 #endif
 #endif
 
+    nrank = -1
+    nproc = -1
+
     return
   end subroutine decomp_2d_finalize
 


### PR DESCRIPTION
* Fix most of the examples. Compilation with gcc tested. The file fftdata is missing in fft_test_r2c

* The library can run even if the external code does not initialize nrank and nproc

* Examples can run with make check

* Update README.md

* Add a test to detect memory leaks

* Fix the example test2d

* Add a "memory" to Makefile execution

This allows building the library, then later testing without needing to specify the options again

* Update README to explain Makefile.settings

* Minor update for the fft_c2c example

* Rewrite halo test to run in memory (without IO)

Also change prow,pcol to 0 so it runs on arbitrary core count

* Abort halo test with non-zero error on failure

* Use decomp_2d_abort instead of MPI_abort in case of error

* Update Makefile for example/halo_test

* example/halo_test : limited output in the build is not debug

* Make tests more flexible wrt parallelism

Use prow=pcol=0

Define MPIRUN, NP (default mpirun, 1) to set mpirun program and number of ranks to run tests

* decomp_2d_comm is needed inside decomp_2d_abort and decomp_2d_warning

Co-authored-by: Paul Bartholomew <p.bartholomew@epcc.ed.ac.uk>
Co-authored-by: Paul <ptb0890@gmail.com>