### PR TITLE
All the decomp_info objects should have the target attribute.

### DIFF
--- a/examples/io_test/io_var_test.f90
+++ b/examples/io_test/io_var_test.f90
@@ -33,7 +33,7 @@ program io_var_test
   complex(mytype), allocatable, dimension(:) :: ctmp
   integer, allocatable, dimension(:) :: itmp
 
-  TYPE(DECOMP_INFO) :: large
+  TYPE(DECOMP_INFO), target :: large
 
   integer :: i,j,k, m, ierror, fh
   character(len=15) :: filename, arg

--- a/src/d2d_log.f90
+++ b/src/d2d_log.f90
@@ -134,11 +134,6 @@ submodule (decomp_2d) d2d_log
     write (io_unit, *) '==========================================================='
     ! Info about each decomp_info object
     call decomp_info_print(decomp_main, io_unit, "decomp_main")
-    call decomp_info_print(phG, io_unit, "phG")
-    call decomp_info_print(ph1, io_unit, "ph1")
-    call decomp_info_print(ph2, io_unit, "ph2")
-    call decomp_info_print(ph3, io_unit, "ph3")
-    call decomp_info_print(ph4, io_unit, "ph4")
 #ifdef SHM_DEBUG
     write (io_unit, *) '==========================================================='
     call print_smp(io_unit)

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -171,7 +171,6 @@ module decomp_2d
 
   ! main (default) decomposition information for global size nx*ny*nz
   TYPE(DECOMP_INFO), save, target, public :: decomp_main
-  TYPE(DECOMP_INFO), save, target, public :: phG,ph1,ph2,ph3,ph4
 
   ! staring/ending index and size of data held by current processor
   ! duplicate 'decomp_main', needed by apps to define data structure 

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -170,8 +170,8 @@ module decomp_2d
   END TYPE DECOMP_INFO
 
   ! main (default) decomposition information for global size nx*ny*nz
-  TYPE(DECOMP_INFO), save, public :: decomp_main
-  TYPE(DECOMP_INFO), save, public :: phG,ph1,ph2,ph3,ph4
+  TYPE(DECOMP_INFO), save, target, public :: decomp_main
+  TYPE(DECOMP_INFO), save, target, public :: phG,ph1,ph2,ph3,ph4
 
   ! staring/ending index and size of data held by current processor
   ! duplicate 'decomp_main', needed by apps to define data structure 

--- a/src/fft_common.f90
+++ b/src/fft_common.f90
@@ -30,8 +30,8 @@ integer, save :: nx_fft, ny_fft, nz_fft
 integer, save, dimension(2) :: dims
 
 ! Decomposition objects
-TYPE(DECOMP_INFO), save :: ph  ! physical space
-TYPE(DECOMP_INFO), save :: sp  ! spectral space
+TYPE(DECOMP_INFO), target, save :: ph  ! physical space
+TYPE(DECOMP_INFO), target, save :: sp  ! spectral space
 
 ! Workspace to store the intermediate Y-pencil data
 ! *** TODO: investigate how to use only one workspace array

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -55,8 +55,8 @@ module decomp_2d_fft
   integer, save, dimension(2) :: dims
 
   ! Decomposition objects
-  TYPE(DECOMP_INFO), save :: ph  ! physical space
-  TYPE(DECOMP_INFO), save :: sp  ! spectral space
+  TYPE(DECOMP_INFO), target, save :: ph  ! physical space
+  TYPE(DECOMP_INFO), target, save :: sp  ! spectral space
 
   ! Workspace to store the intermediate Y-pencil data
   ! *** TODO: investigate how to use only one workspace array

--- a/src/halo.f90
+++ b/src/halo.f90
@@ -19,10 +19,10 @@
     integer, intent(IN) :: level      ! levels of halo cells required
     real(mytype), dimension(:,:,:), intent(IN) :: in    
     real(mytype), allocatable, dimension(:,:,:), intent(OUT) :: out
-    TYPE(DECOMP_INFO), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, optional :: opt_decomp
     logical, optional :: opt_global
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
     logical :: global
 
     ! starting/ending index of array with halo cells
@@ -52,10 +52,10 @@
     integer, intent(IN) :: level      ! levels of halo cells required
     complex(mytype), dimension(:,:,:), intent(IN) :: in    
     complex(mytype), allocatable, dimension(:,:,:), intent(OUT) :: out
-    TYPE(DECOMP_INFO), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, optional :: opt_decomp
     logical, optional :: opt_global
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
     logical :: global
 
     ! starting/ending index of array with halo cells

--- a/src/halo_common.f90
+++ b/src/halo_common.f90
@@ -13,9 +13,9 @@
 ! 'update_halo_...' in halo.f90
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     if (present(opt_global)) then
@@ -468,3 +468,5 @@
        ! all data in local memory already, no halo exchange
 
     end if  ! pencil
+
+    nullify(decomp)

--- a/src/transpose_x_to_y.f90
+++ b/src/transpose_x_to_y.f90
@@ -17,9 +17,9 @@
     
     Real(mytype), dimension(:,:,:), intent(IN) :: src
     real(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -40,9 +40,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -137,6 +137,8 @@
 
 #endif
 
+    nullify(decomp)
+
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_r")
 #endif
@@ -152,9 +154,9 @@
     
     complex(mytype), dimension(:,:,:), intent(IN) :: src
     complex(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -175,9 +177,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -259,6 +261,8 @@
 #endif
 
 #endif
+
+    nullify(decomp)
 
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_x_y_c")

--- a/src/transpose_y_to_x.f90
+++ b/src/transpose_y_to_x.f90
@@ -17,9 +17,9 @@
     
     real(mytype), dimension(:,:,:), intent(IN) :: src
     real(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -40,9 +40,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -137,6 +137,8 @@
 
 #endif
 
+    nullify(decomp)
+
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_r")
 #endif
@@ -151,9 +153,9 @@
     
     complex(mytype), dimension(:,:,:), intent(IN) :: src
     complex(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -174,9 +176,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -258,6 +260,8 @@
 #endif
 
 #endif
+
+    nullify(decomp)
 
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_x_c")

--- a/src/transpose_y_to_z.f90
+++ b/src/transpose_y_to_z.f90
@@ -17,9 +17,9 @@
     
     real(mytype), dimension(:,:,:), intent(IN) :: src
     real(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -41,9 +41,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -149,6 +149,8 @@
 #endif
 #endif
 
+    nullify(decomp)
+
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_r")
 #endif
@@ -163,9 +165,9 @@
     
     complex(mytype), dimension(:,:,:), intent(IN) :: src
     complex(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
     
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -187,9 +189,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -281,6 +283,8 @@
 
 #endif
 #endif
+
+    nullify(decomp)
 
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_y_z_c")

--- a/src/transpose_z_to_y.f90
+++ b/src/transpose_z_to_y.f90
@@ -17,9 +17,9 @@
     
     real(mytype), dimension(:,:,:), intent(IN) :: src
     real(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -40,9 +40,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -145,6 +145,8 @@
 
 #endif
 
+    nullify(decomp)
+
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_r")
 #endif
@@ -159,9 +161,9 @@
     
     complex(mytype), dimension(:,:,:), intent(IN) :: src
     complex(mytype), dimension(:,:,:), intent(OUT) :: dst
-    TYPE(DECOMP_INFO), intent(IN), optional :: opt_decomp
+    TYPE(DECOMP_INFO), target, intent(IN), optional :: opt_decomp
 
-    TYPE(DECOMP_INFO) :: decomp
+    TYPE(DECOMP_INFO), pointer :: decomp
 
 #if defined(_GPU)
 #if defined(_NCCL)
@@ -182,9 +184,9 @@
 #endif
 
     if (present(opt_decomp)) then
-       decomp = opt_decomp
+       decomp => opt_decomp
     else
-       decomp = decomp_main
+       decomp => decomp_main
     end if
 
     s1 = SIZE(src,1)
@@ -277,6 +279,8 @@
 #endif
 
 #endif
+
+    nullify(decomp)
 
 #ifdef PROFILER
     if (decomp_profiler_transpose) call decomp_profiler_end("transp_z_y_c")


### PR DESCRIPTION
This avoids a copy of the decomp_info object at each halo / transpose operation.

This modification is important because it can impact the codes using the decomp2d library.