### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,5 +134,6 @@ Makefile.settings:
 	echo "INC = $(INC)" >> $@
 	echo "LIBOPT = $(LIBOPT)" >> $@
 	echo "LIBFFT = ${LIBFFT}" >> $@
+	echo "LFLAGS = $(LFLAGS)" >> $@
 
 export


### PR DESCRIPTION
Add missing variable LFLAGS in Makefile.settings. This variable is used by the profiler and in the examples.