### PR TITLE
Use BUILD=dev for default/fast build test on GH

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -28,7 +28,7 @@ jobs:
 
     # Runs a set of commands using the runners shell
     - name: Compile
-      run: make BUILD=debug
+      run: make BUILD=dev
 
     - name: Examples
       run: make examples


### PR DESCRIPTION
This makes sure the code has been built with the strictest flags