### PR TITLE
Add - infront of include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ OBJDECOMP = $(SRCDECOMP_:$(SRCDIR)/%.f90=$(OBJDIR)/%.o)
 OPT += $(OPTIO)
 INC += $(INCIO)
 
-include Makefile.settings
+-include Makefile.settings
 
 all: $(DECOMPINC) $(OBJDIR) $(LIBDECOMP)
 


### PR DESCRIPTION
This prevents an error occurring when Makefile.settings does not exist (e.g. after make clean)