### PR TITLE
Delete old mem_leak target referencing timing in fft_physical_z

### DIFF
--- a/examples/fft_physical_z/Makefile
+++ b/examples/fft_physical_z/Makefile
@@ -24,9 +24,6 @@ endif
 mem_leak:
 	valgrind --leak-check=full --show-leak-kinds=all $(MPIRUN) -n 1 ./fft_physical_z 1 1
 
-mem_leak:
-	valgrind --leak-check=full --show-leak-kinds=all mpirun -n 1 ./timing 1 1
-
 clean:
 	rm -f *.o fft_physical_z *.log
 


### PR DESCRIPTION
I'm assuming this is a clear-cut old piece of old code but thought worth checking with you @rfj82982 