### PR TITLE
Separate fft examples

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,14 +1,14 @@
-.PHONY: test2d fft_physical_z fft_physical_x halo_test init_test io_test 
+.PHONY: test2d fft_physical_x fft_physical_z halo_test init_test io_test 
 
 # Just build the examples
-examples: test2d fft_physical_z fft_physical_x halo_test init_test io_test
+examples: test2d fft_physical_x fft_physical_z halo_test init_test io_test
 	@echo "Built the examples"
 
 test2d:
 	$(MAKE) -C $@ $@
-fft_physical_z:
-	$(MAKE) -C $@ $@
 fft_physical_x:
+	$(MAKE) -C $@ all
+fft_physical_z:
 	$(MAKE) -C $@ all
 halo_test:
 	$(MAKE) -C $@ $@
@@ -19,16 +19,16 @@ io_test:
 
 check:
 	cd test2d; $(MAKE) $@
-	cd fft_physical_z; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
+	cd fft_physical_z; $(MAKE) $@
 	cd halo_test; $(MAKE) $@
 	cd init_test; $(MAKE) $@
 	cd io_test; $(MAKE) $@
 
 clean:
 	cd test2d; $(MAKE) $@
-	cd fft_physical_z; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
+	cd fft_physical_z; $(MAKE) $@
 	cd halo_test; $(MAKE) $@
 	cd init_test; $(MAKE) $@
 	cd io_test; $(MAKE) $@

--- a/examples/fft_physical_x/Makefile
+++ b/examples/fft_physical_x/Makefile
@@ -8,9 +8,12 @@ LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT) $(LFLAGS)
 NP ?= 1
 MPIRUN ?= mpirun
 
-all: fft_physical_x fft_grid_x
+all: fft_c2c_x fft_r2c_x fft_grid_x
 
-fft_physical_x: fft_physical_x.o
+fft_c2c_x: fft_c2c_x.o
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
+
+fft_r2c_x: fft_r2c_x.o
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 fft_grid_x: fft_grid_x.o
@@ -18,19 +21,21 @@ fft_grid_x: fft_grid_x.o
 
 ifeq ($(PARAMOD),gpu)
 check:
-	$(MPIRUN) -n $(NP) ./bind.sh ./fft_physical_x
+	$(MPIRUN) -n $(NP) ./bind.sh ./fft_c2c_x
+	$(MPIRUN) -n $(NP) ./bind.sh ./fft_r2c_x
 	$(MPIRUN) -n $(NP) ./bind.sh ./fft_grid_x
 else
 check:
-	$(MPIRUN) -n $(NP) ./fft_physical_x
+	$(MPIRUN) -n $(NP) ./fft_c2c_x
+	$(MPIRUN) -n $(NP) ./fft_r2c_x
 	$(MPIRUN) -n $(NP) ./fft_grid_x
 endif
 
 mem_leak:
-	valgrind --leak-check=full --show-leak-kinds=all $(MPIRUN) -n 1 ./fft_physical_x 1 1
+	valgrind --leak-check=full --show-leak-kinds=all $(MPIRUN) -n 1 ./fft_c2c_x 1 1
 
 clean:
-	rm -f *.o fft_physical_x fft_grid_x *.log
+	rm -f *.o fft_c2c_x fft_r2c_x fft_grid_x *.log
 
 %.o : %.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/fft_physical_x/fft_c2c_x.f90
+++ b/examples/fft_physical_x/fft_c2c_x.f90
@@ -20,9 +20,6 @@ program fft_c2c_x
   integer, parameter :: ntest = 10  ! repeat test this times
   
   complex(mytype), allocatable, dimension(:,:,:) :: in, out
-  real(mytype), allocatable, dimension(:,:,:) :: in_r
-  
-  integer, dimension(3) :: fft_start, fft_end, fft_size
   
   real(mytype) :: dr,di, error, err_all, n1,flops
   integer :: ierror, i,j,k,m

--- a/examples/fft_physical_x/fft_c2c_x.f90
+++ b/examples/fft_physical_x/fft_c2c_x.f90
@@ -1,0 +1,131 @@
+program fft_c2c_x
+
+  use decomp_2d
+  use decomp_2d_fft
+  use MPI
+#if defined(_GPU) 
+  use cudafor
+  use cufft
+  use openacc 
+#endif
+
+  implicit none
+  
+  integer, parameter :: nx_base=17, ny_base=13, nz_base=11
+  integer :: nx, ny, nz
+  integer :: p_row=0, p_col=0
+  integer :: resize_domain
+  integer :: nranks_tot
+  
+  integer, parameter :: ntest = 10  ! repeat test this times
+  
+  complex(mytype), allocatable, dimension(:,:,:) :: in, out
+  real(mytype), allocatable, dimension(:,:,:) :: in_r
+  
+  integer, dimension(3) :: fft_start, fft_end, fft_size
+  
+  real(mytype) :: dr,di, error, err_all, n1,flops
+  integer :: ierror, i,j,k,m
+  real(mytype) :: t1, t2, t3 ,t4
+  
+  call MPI_INIT(ierror)
+  ! To resize the domain we need to know global number of ranks
+  ! This operation is also done as part of decomp_2d_init
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
+  resize_domain = int(nranks_tot/4)+1
+  nx = nx_base*resize_domain
+  ny = ny_base*resize_domain
+  nz = nz_base*resize_domain
+  call decomp_2d_init(nx,ny,nz,p_row,p_col)
+
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  ! Test the c2c interface
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  call decomp_2d_fft_init(PHYSICAL_IN_X) ! force the default x pencil
+
+  !  input is X-pencil data
+  ! output is Z-pencil data
+  allocate (in(xstart(1):xend(1),xstart(2):xend(2),xstart(3):xend(3)))
+  allocate (out(zstart(1):zend(1),zstart(2):zend(2),zstart(3):zend(3)))
+  ! initilise input
+  do k=xstart(3),xend(3)
+     do j=xstart(2),xend(2)
+        do i=xstart(1),xend(1)
+           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
+                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
+           di = dr
+           in(i,j,k) = cmplx(dr,di,mytype)
+        end do
+     end do
+  end do
+  
+  t2 = 0._mytype
+  t4 = 0._mytype
+  do m=1,ntest
+     
+     ! forward FFT
+     t1 = MPI_WTIME()
+     call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
+     t2 = t2 + MPI_WTIME() - t1
+
+     ! inverse FFT
+     t3 = MPI_WTIME()
+     call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
+     t4 = t4 + MPI_WTIME() - t3
+  
+     ! normalisation - note 2DECOMP&FFT doesn't normalise
+     !$acc kernels
+     in = in / real(nx,mytype) / real(ny,mytype) /real(nz,mytype)
+     !$acc end kernels
+
+  end do
+#if defined(_GPU)
+  ierror = cudaDeviceSynchronize()
+#endif
+  
+  call MPI_ALLREDUCE(t2,t1,1,real_type,MPI_SUM, &
+       MPI_COMM_WORLD,ierror)
+  t1 = t1 / real(nproc,mytype)
+  call MPI_ALLREDUCE(t4,t3,1,real_type,MPI_SUM, &
+       MPI_COMM_WORLD,ierror)
+  t3 = t3 / real(nproc,mytype)
+  
+  ! checking accuracy
+  error = 0._mytype
+  do k=xstart(3),xend(3)
+     do j=xstart(2),xend(2)
+        do i=xstart(1),xend(1)
+           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
+                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
+           di = dr
+           dr = dr - real(in(i,j,k),mytype)
+           di = di - aimag(in(i,j,k))
+           error = error + sqrt(dr*dr + di*di)
+        end do
+     end do
+  end do
+  call MPI_ALLREDUCE(error,err_all,1,real_type,MPI_SUM,MPI_COMM_WORLD,ierror)
+  err_all = err_all / real(nx,mytype) / real(ny,mytype) / real(nz,mytype)
+
+  if (nrank==0) then
+     write(*,*) '===== c2c interface ====='
+     write(*,*) 'error / mesh point: ', err_all 
+     write(*,*) 'time (sec): ', t1,t3
+     n1 = real(nx,mytype) * real(ny,mytype) * real(nz,mytype)
+     n1 = n1 ** (1._mytype/3._mytype)
+     ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
+     flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
+     ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
+     flops = flops * 3._mytype * n1**2  
+     flops = 2._mytype * flops / ((t1+t3)/real(NTEST,mytype))
+     write(*,*) 'GFLOPS : ', flops / 1000._mytype**3
+  end if
+  
+  deallocate(in,out)
+  call decomp_2d_fft_finalize
+  call decomp_2d_finalize
+  call MPI_FINALIZE(ierror)
+
+end program fft_c2c_x
+

--- a/examples/fft_physical_x/fft_r2c_x.f90
+++ b/examples/fft_physical_x/fft_r2c_x.f90
@@ -1,4 +1,4 @@
-program fft_physical_x
+program fft_r2c_x
 
   use decomp_2d
   use decomp_2d_fft
@@ -37,94 +37,6 @@ program fft_physical_x
   ny = ny_base*resize_domain
   nz = nz_base*resize_domain
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  ! Test the c2c interface
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-  call decomp_2d_fft_init(PHYSICAL_IN_X) ! force the default x pencil
-
-  !  input is X-pencil data
-  ! output is Z-pencil data
-  allocate (in(xstart(1):xend(1),xstart(2):xend(2),xstart(3):xend(3)))
-  allocate (out(zstart(1):zend(1),zstart(2):zend(2),zstart(3):zend(3)))
-  ! initilise input
-  do k=xstart(3),xend(3)
-     do j=xstart(2),xend(2)
-        do i=xstart(1),xend(1)
-           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
-                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
-           di = dr
-           in(i,j,k) = cmplx(dr,di,mytype)
-        end do
-     end do
-  end do
-  
-  t2 = 0._mytype
-  t4 = 0._mytype
-  do m=1,ntest
-     
-     ! forward FFT
-     t1 = MPI_WTIME()
-     call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
-     t2 = t2 + MPI_WTIME() - t1
-
-     ! inverse FFT
-     t3 = MPI_WTIME()
-     call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
-     t4 = t4 + MPI_WTIME() - t3
-  
-     ! normalisation - note 2DECOMP&FFT doesn't normalise
-     !$acc kernels
-     in = in / real(nx,mytype) / real(ny,mytype) /real(nz,mytype)
-     !$acc end kernels
-
-  end do
-#if defined(_GPU)
-  ierror = cudaDeviceSynchronize()
-#endif
-  
-  call MPI_ALLREDUCE(t2,t1,1,real_type,MPI_SUM, &
-       MPI_COMM_WORLD,ierror)
-  t1 = t1 / real(nproc,mytype)
-  call MPI_ALLREDUCE(t4,t3,1,real_type,MPI_SUM, &
-       MPI_COMM_WORLD,ierror)
-  t3 = t3 / real(nproc,mytype)
-  
-  ! checking accuracy
-  error = 0._mytype
-  do k=xstart(3),xend(3)
-     do j=xstart(2),xend(2)
-        do i=xstart(1),xend(1)
-           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
-                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
-           di = dr
-           dr = dr - real(in(i,j,k),mytype)
-           di = di - aimag(in(i,j,k))
-           error = error + sqrt(dr*dr + di*di)
-        end do
-     end do
-  end do
-  call MPI_ALLREDUCE(error,err_all,1,real_type,MPI_SUM,MPI_COMM_WORLD,ierror)
-  err_all = err_all / real(nx,mytype) / real(ny,mytype) / real(nz,mytype)
-
-  if (nrank==0) then
-     write(*,*) '===== c2c interface ====='
-     write(*,*) 'error / mesh point: ', err_all 
-     write(*,*) 'time (sec): ', t1,t3
-     n1 = real(nx,mytype) * real(ny,mytype) * real(nz,mytype)
-     n1 = n1 ** (1._mytype/3._mytype)
-     ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
-     flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
-     ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
-     flops = flops * 3._mytype * n1**2  
-     flops = 2._mytype * flops / ((t1+t3)/real(NTEST,mytype))
-     write(*,*) 'GFLOPS : ', flops / 1000._mytype**3
-  end if
-  
-  deallocate(in,out)
-  call decomp_2d_fft_finalize
-
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Test the r2c/c2r interface
@@ -203,5 +115,5 @@ program fft_physical_x
   call decomp_2d_finalize
   call MPI_FINALIZE(ierror)
 
-end program fft_physical_x
+end program fft_r2c_x
 

--- a/examples/fft_physical_x/fft_r2c_x.f90
+++ b/examples/fft_physical_x/fft_r2c_x.f90
@@ -19,12 +19,12 @@ program fft_r2c_x
   
   integer, parameter :: ntest = 10  ! repeat test this times
   
-  complex(mytype), allocatable, dimension(:,:,:) :: in, out
+  complex(mytype), allocatable, dimension(:,:,:) :: out
   real(mytype), allocatable, dimension(:,:,:) :: in_r
   
   integer, dimension(3) :: fft_start, fft_end, fft_size
   
-  real(mytype) :: dr,di, error, err_all, n1,flops
+  real(mytype) :: dr, error, err_all
   integer :: ierror, i,j,k,m
   real(mytype) :: t1, t2, t3 ,t4
   

--- a/examples/fft_physical_z/Makefile
+++ b/examples/fft_physical_z/Makefile
@@ -5,27 +5,32 @@ FFLAGS := $(subst $(MODFLAG),$(MODFLAG)../../,$(FFLAGS))
 FFLAGS := $(patsubst -I%,-I../../%,$(FFLAGS))
 LIBS = -L../../ -l$(LIBDECOMP) $(LIBFFT) $(LFLAGS)
 
-OBJ = fft_physical_z.o
-
 NP ?= 1
 MPIRUN ?= mpirun
 
-fft_physical_z: $(OBJ)
-	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
+all: fft_c2c_z fft_r2c_z 
+
+fft_c2c_z: fft_c2c_z.o
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
+
+fft_r2c_z: fft_r2c_z.o
+	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $< $(OBJ) $(LIBS)
 
 ifeq ($(PARAMOD),gpu)
 check:
-	$(MPIRUN) -n $(NP) ./bind.sh ./fft_physical_z
+	$(MPIRUN) -n $(NP) ./bind.sh ./fft_c2c_z
+	$(MPIRUN) -n $(NP) ./bind.sh ./fft_r2c_z
 else
 check:
-	$(MPIRUN) -n $(NP) ./fft_physical_z
+	$(MPIRUN) -n $(NP) ./fft_c2c_z
+	$(MPIRUN) -n $(NP) ./fft_r2c_z
 endif
 
 mem_leak:
-	valgrind --leak-check=full --show-leak-kinds=all $(MPIRUN) -n 1 ./fft_physical_z 1 1
+	valgrind --leak-check=full --show-leak-kinds=all $(MPIRUN) -n 1 ./fft_c2c_z 1 1
 
 clean:
-	rm -f *.o fft_physical_z *.log
+	rm -f *.o fft_c2c_z fft_r2c_z *.log
 
 %.o : %.f90
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -c $< -o $@

--- a/examples/fft_physical_z/fft_c2c_z.f90
+++ b/examples/fft_physical_z/fft_c2c_z.f90
@@ -21,10 +21,7 @@ program fft_c2c_z
   integer, parameter :: ntest = 10  ! repeat test this times
   
   complex(mytype), allocatable, dimension(:,:,:) :: in, out
-  real(mytype), allocatable, dimension(:,:,:) :: in_r
 
-  integer, dimension(3) :: fft_start, fft_end, fft_size
-  
   real(mytype) :: dr,di, error, err_all, n1,flops
   integer :: ierror, i,j,k,m
   real(mytype) :: t1, t2, t3 ,t4

--- a/examples/fft_physical_z/fft_c2c_z.f90
+++ b/examples/fft_physical_z/fft_c2c_z.f90
@@ -1,0 +1,130 @@
+program fft_c2c_z
+
+  use decomp_2d
+  use decomp_2d_fft
+  use MPI
+#if defined(_GPU) 
+  use cudafor
+  use cufft
+  use openacc 
+#endif
+
+  implicit none
+  
+  !integer, parameter :: nx_base=4, ny_base=2, nz_base=3
+  integer, parameter :: nx_base=17, ny_base=13, nz_base=11
+  integer :: nx, ny, nz
+  integer :: p_row=0, p_col=0
+  integer :: resize_domain
+  integer :: nranks_tot
+  
+  integer, parameter :: ntest = 10  ! repeat test this times
+  
+  complex(mytype), allocatable, dimension(:,:,:) :: in, out
+  real(mytype), allocatable, dimension(:,:,:) :: in_r
+
+  integer, dimension(3) :: fft_start, fft_end, fft_size
+  
+  real(mytype) :: dr,di, error, err_all, n1,flops
+  integer :: ierror, i,j,k,m
+  real(mytype) :: t1, t2, t3 ,t4
+  
+  call MPI_INIT(ierror)
+  ! To resize the domain we need to know global number of ranks
+  ! This operation is also done as part of decomp_2d_init
+  call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
+  resize_domain = int(nranks_tot/4)+1
+  nx = nx_base*resize_domain
+  ny = ny_base*resize_domain
+  nz = nz_base*resize_domain
+  call decomp_2d_init(nx,ny,nz,p_row,p_col)
+
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  ! Test the c2c interface
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  call decomp_2d_fft_init(PHYSICAL_IN_Z) ! non-default Z-pencil input
+  !  input is Z-pencil data
+  ! output is X-pencil data
+  allocate (in(zstart(1):zend(1),zstart(2):zend(2),zstart(3):zend(3)))
+  allocate (out(xstart(1):xend(1),xstart(2):xend(2),xstart(3):xend(3)))
+  ! initilise input
+  do k=zstart(3),zend(3)
+     do j=zstart(2),zend(2)
+        do i=zstart(1),zend(1)
+           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
+                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
+           di = dr
+           in(i,j,k) = cmplx(dr,di,mytype)
+        end do
+     end do
+  end do
+  
+  t2 = 0._mytype
+  t4 = 0._mytype
+  do m=1,ntest
+     
+     ! forward FFT
+     t1 = MPI_WTIME()
+     call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
+     t2 = t2 + MPI_WTIME() - t1
+
+     ! inverse FFT
+     t3 = MPI_WTIME()
+     call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
+     t4 = t4 + MPI_WTIME() - t3
+  
+     ! normalisation - note 2DECOMP&FFT doesn't normalise
+     !$acc kernels
+     in = in / real(nx,mytype) / real(ny,mytype) /real(nz,mytype)
+     !$acc end kernels
+
+  end do
+#if defined(_GPU)
+  ierror = cudaDeviceSynchronize()
+#endif
+  
+
+  call MPI_ALLREDUCE(t2,t1,1,real_type,MPI_SUM, &
+       MPI_COMM_WORLD,ierror)
+  t1 = t1 / real(nproc,mytype)
+  call MPI_ALLREDUCE(t4,t3,1,real_type,MPI_SUM, &
+       MPI_COMM_WORLD,ierror)
+  t3 = t3 / real(nproc,mytype)
+  
+  ! checking accuracy
+  error = 0._mytype
+  do k=zstart(3),zend(3)
+     do j=zstart(2),zend(2)
+        do i=zstart(1),zend(1)
+           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
+                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
+           di = dr
+           dr = dr - real(in(i,j,k),mytype)
+           di = di - aimag(in(i,j,k))
+           error = error + sqrt(dr*dr + di*di)
+        end do
+     end do
+  end do
+  call MPI_ALLREDUCE(error,err_all,1,real_type,MPI_SUM,MPI_COMM_WORLD,ierror)
+  err_all = err_all / real(nx,mytype) / real(ny,mytype) / real(nz,mytype)
+
+  if (nrank==0) then
+     write(*,*) '===== c2c interface ====='
+     write(*,*) 'error / mesh point: ', err_all 
+     write(*,*) 'time (sec): ', t1,t3
+     n1 = real(nx,mytype) * real(ny,mytype) * real(nz,mytype)
+     n1 = n1 ** (1._mytype/3._mytype)
+     ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
+     flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
+     ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
+     flops = flops * 3._mytype * n1**2  
+     flops = 2._mytype * flops / ((t1+t3)/real(NTEST,mytype))
+     write(*,*) 'GFLOPS : ', flops / 1000._mytype**3
+  end if
+  
+  deallocate(in,out)
+  call decomp_2d_fft_finalize
+  call decomp_2d_finalize
+  call MPI_FINALIZE(ierror)
+
+end program fft_c2c_z

--- a/examples/fft_physical_z/fft_r2c_z.f90
+++ b/examples/fft_physical_z/fft_r2c_z.f90
@@ -20,12 +20,12 @@ program fft_r2c_z
   
   integer, parameter :: ntest = 10  ! repeat test this times
   
-  complex(mytype), allocatable, dimension(:,:,:) :: in, out
+  complex(mytype), allocatable, dimension(:,:,:) :: out
   real(mytype), allocatable, dimension(:,:,:) :: in_r
 
   integer, dimension(3) :: fft_start, fft_end, fft_size
   
-  real(mytype) :: dr,di, error, err_all, n1,flops
+  real(mytype) :: dr, error, err_all
   integer :: ierror, i,j,k,m
   real(mytype) :: t1, t2, t3 ,t4
   

--- a/examples/fft_physical_z/fft_r2c_z.f90
+++ b/examples/fft_physical_z/fft_r2c_z.f90
@@ -1,4 +1,4 @@
-program fft_physical_z
+program fft_r2c_z
 
   use decomp_2d
   use decomp_2d_fft
@@ -38,93 +38,6 @@ program fft_physical_z
   ny = ny_base*resize_domain
   nz = nz_base*resize_domain
   call decomp_2d_init(nx,ny,nz,p_row,p_col)
-
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  ! Test the c2c interface
-  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  call decomp_2d_fft_init(PHYSICAL_IN_Z) ! non-default Z-pencil input
-  !  input is Z-pencil data
-  ! output is X-pencil data
-  allocate (in(zstart(1):zend(1),zstart(2):zend(2),zstart(3):zend(3)))
-  allocate (out(xstart(1):xend(1),xstart(2):xend(2),xstart(3):xend(3)))
-  ! initilise input
-  do k=zstart(3),zend(3)
-     do j=zstart(2),zend(2)
-        do i=zstart(1),zend(1)
-           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
-                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
-           di = dr
-           in(i,j,k) = cmplx(dr,di,mytype)
-        end do
-     end do
-  end do
-  
-  t2 = 0._mytype
-  t4 = 0._mytype
-  do m=1,ntest
-     
-     ! forward FFT
-     t1 = MPI_WTIME()
-     call decomp_2d_fft_3d(in, out, DECOMP_2D_FFT_FORWARD)
-     t2 = t2 + MPI_WTIME() - t1
-
-     ! inverse FFT
-     t3 = MPI_WTIME()
-     call decomp_2d_fft_3d(out, in, DECOMP_2D_FFT_BACKWARD)
-     t4 = t4 + MPI_WTIME() - t3
-  
-     ! normalisation - note 2DECOMP&FFT doesn't normalise
-     !$acc kernels
-     in = in / real(nx,mytype) / real(ny,mytype) /real(nz,mytype)
-     !$acc end kernels
-
-  end do
-#if defined(_GPU)
-  ierror = cudaDeviceSynchronize()
-#endif
-  
-
-  call MPI_ALLREDUCE(t2,t1,1,real_type,MPI_SUM, &
-       MPI_COMM_WORLD,ierror)
-  t1 = t1 / real(nproc,mytype)
-  call MPI_ALLREDUCE(t4,t3,1,real_type,MPI_SUM, &
-       MPI_COMM_WORLD,ierror)
-  t3 = t3 / real(nproc,mytype)
-  
-  ! checking accuracy
-  error = 0._mytype
-  do k=zstart(3),zend(3)
-     do j=zstart(2),zend(2)
-        do i=zstart(1),zend(1)
-           dr = real(i,mytype)/real(nx,mytype)*real(j,mytype) &
-                /real(ny,mytype)*real(k,mytype)/real(nz,mytype)
-           di = dr
-           dr = dr - real(in(i,j,k),mytype)
-           di = di - aimag(in(i,j,k))
-           error = error + sqrt(dr*dr + di*di)
-        end do
-     end do
-  end do
-  call MPI_ALLREDUCE(error,err_all,1,real_type,MPI_SUM,MPI_COMM_WORLD,ierror)
-  err_all = err_all / real(nx,mytype) / real(ny,mytype) / real(nz,mytype)
-
-  if (nrank==0) then
-     write(*,*) '===== c2c interface ====='
-     write(*,*) 'error / mesh point: ', err_all 
-     write(*,*) 'time (sec): ', t1,t3
-     n1 = real(nx,mytype) * real(ny,mytype) * real(nz,mytype)
-     n1 = n1 ** (1._mytype/3._mytype)
-     ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
-     flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
-     ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
-     flops = flops * 3._mytype * n1**2  
-     flops = 2._mytype * flops / ((t1+t3)/real(NTEST,mytype))
-     write(*,*) 'GFLOPS : ', flops / 1000._mytype**3
-  end if
-  
-  deallocate(in,out)
-  call decomp_2d_fft_finalize
-
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   ! Test the r2c/c2r interface
@@ -205,4 +118,4 @@ program fft_physical_z
   call decomp_2d_finalize
   call MPI_FINALIZE(ierror)
 
-end program fft_physical_z
+end program fft_r2c_z


### PR DESCRIPTION
Split of the FFT examples into c2c and r2c. Tested on gnu/mpich, intel and nvhpc with all working. Only annoyance is the following warning from Intel
```
mpiifort  -fpp -std08 -O3 -mavx2 -march=core-avx2 -mtune=core-avx2 -module mod -Imod  -DDOUBLE_PREC -DVERSION=\"e8f2cc6\"  -c src/log.f90 -o obj/log.o

src/log.f90(85): warning #7416: Fortran 2008 does not allow this intrinsic procedure.   [COMPILER_VERSION]
    write (io_unit, *) 'Compiled with ', compiler_version()
-----------------------------------------^

src/log.f90(86): warning #7416: Fortran 2008 does not allow this intrinsic procedure.   [COMPILER_OPTIONS]
    write (io_unit, *) 'Compiler options : ', compiler_options()
----------------------------------------------^

mpiifort  -fpp -std08 -O3 -mavx2 -march=core-avx2 -mtune=core-avx2 -module mod -Imod  -DDOUBLE_PREC -DVERSION=\"e8f2cc6\"  -c src/io.f90 -o obj/io.o

src/io.f90(1411): warning #7346: The CHARACTER* form of a CHARACTER declaration is an obsolescent feature in Fortran 2008.
    character*(*), intent(in) :: varname
---------------^
```