### PR TITLE
MKL inplace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,11 @@
 #   -DDOUBLE_PREC - use double-precision
 #   -DSAVE_SINGLE - Save 3D data in single-precision
 #   -DDEBG        - debugging
+#   -DOVERWIR     - Enable overwriting optimisation in MKL FFT
 # generate a Git version string
 GIT_VERSION := $(shell git describe --tag --long --always)
 
-DEFS = -DDOUBLE_PREC -DVERSION=\"$(GIT_VERSION)\"
+DEFS = -DDOUBLE_PREC -DVERSION=\"$(GIT_VERSION)\" -DOVERWRITE
 
 LCL = local# local,lad,sdu,archer
 CMP = gcc# intel,gcc,nagfor,cray,nvhpc

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 # generate a Git version string
 GIT_VERSION := $(shell git describe --tag --long --always)
 
-DEFS = -DDOUBLE_PREC -DVERSION=\"$(GIT_VERSION)\" -DOVERWRITE
+DEFS = -DDOUBLE_PREC -DVERSION=\"$(GIT_VERSION)\"
 
 LCL = local# local,lad,sdu,archer
 CMP = gcc# intel,gcc,nagfor,cray,nvhpc

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -504,7 +504,7 @@ module decomp_2d_fft
       real(mytype), dimension(:, :, :), intent(IN) :: in_r
       complex(mytype), dimension(:, :, :), intent(OUT) :: out_c
 
-      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2, wk2b, wk3
+      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -522,27 +522,26 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_r2c")
 
          ! ===== Swap X --> Y =====
-         allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
-         call transpose_x_to_y(wk1, wk2, sp)
+         call transpose_x_to_y(wk1, wk2_r2c, sp)
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, sp%ysz(3)
-            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y2, wk2_r2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeForward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
-            status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y2, wk2_r2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
 
          ! ===== Swap Y --> Z =====
 #ifdef OVERWRITE
-         call transpose_y_to_z(wk2, out_c, sp)
+         call transpose_y_to_z(wk2_r2c, out_c, sp)
 #else
          allocate (wk3(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
          call transpose_y_to_z(wk2b, wk3, sp)
@@ -566,27 +565,26 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_r2c")
 
          ! ===== Swap Z --> Y =====
-         allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
-         call transpose_z_to_y(wk1, wk2, sp)
+         call transpose_z_to_y(wk1, wk2_r2c, sp)
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, sp%ysz(3)
-            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y2, wk2_r2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeForward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
-            status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y2, wk2_r2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
 
          ! ===== Swap Y --> X =====
 #ifdef OVERWRITE
-         call transpose_y_to_x(wk2, out_c, sp)
+         call transpose_y_to_x(wk2_r2c, out_c, sp)
 #else
          allocate (wk3(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
          call transpose_y_to_x(wk2b, wk3, sp)

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -349,7 +349,7 @@ module decomp_2d_fft
       complex(mytype), dimension(:, :, :), intent(OUT) :: out
       integer, intent(IN) :: isign
 
-      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2, wk2b, wk3
+      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
       integer :: k, status
 
 #ifdef PROFILER
@@ -374,17 +374,16 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap X --> Y =====
-         allocate (wk2(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
 #ifdef OVERWRITE
-         call transpose_x_to_y(in, wk2, ph)
+         call transpose_x_to_y(in, wk2_c2c, ph)
 #else
-         call transpose_x_to_y(wk1, wk2, ph)
+         call transpose_x_to_y(wk1, wk2_c2c, ph)
 #endif
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, ph%xsz(3)
-            status = wrapper_c2c_inplace(c2c_y, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y, wk2_c2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
@@ -395,14 +394,14 @@ module decomp_2d_fft
             !          else if (isign==DECOMP_2D_FFT_BACKWARD) then
             !             status = DftiComputeBackward(c2c_y, wk2(:,1,k), wk2b(:,1,k))
             !          end if
-            status = wrapper_c2c(c2c_y, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y, wk2_c2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
 
          ! ===== Swap Y --> Z =====
 #ifdef OVERWRITE
-         call transpose_y_to_z(wk2, out, ph)
+         call transpose_y_to_z(wk2_c2c, out, ph)
 #else
          allocate (wk3(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
          call transpose_y_to_z(wk2b, wk3, ph)
@@ -440,17 +439,16 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap Z --> Y =====
-         allocate (wk2(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
 #ifdef OVERWRITE
-         call transpose_z_to_y(in, wk2, ph)
+         call transpose_z_to_y(in, wk2_c2c, ph)
 #else
-         call transpose_z_to_y(wk1, wk2, ph)
+         call transpose_z_to_y(wk1, wk2_c2c, ph)
 #endif
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, ph%xsz(3)
-            status = wrapper_c2c_inplace(c2c_y, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y, wk2_c2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
@@ -461,14 +459,14 @@ module decomp_2d_fft
             !          else if (isign==DECOMP_2D_FFT_BACKWARD) then
             !             status = DftiComputeBackward(c2c_y, wk2(:,1,k), wk2b(:,1,k))
             !          end if
-            status = wrapper_c2c(c2c_y, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y, wk2_c2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
 
          ! ===== Swap Y --> X =====
 #ifdef OVERWRITE
-         call transpose_y_to_x(wk2, out, ph)
+         call transpose_y_to_x(wk2_c2c, out, ph)
 #else
          allocate (wk3(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
          call transpose_y_to_x(wk2b, wk3, ph)

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -796,7 +796,7 @@ module decomp_2d_fft
          status = DftiComputeBackward(desc, inout)
       end if
 
-      wrapper_c2c = status
+      wrapper_c2c_inplace = status
 
       return
    end function wrapper_c2c_inplace

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -46,9 +46,6 @@ module decomp_2d_fft
          write (*, *) '***** Using the MKL engine *****'
          write (*, *) ' '
       end if
-#ifdef OVERWRITE
-      call decomp_2d_warning(0, "MKL FFT engine does not support the OVERWRITE flag.")
-#endif
 
       ! For C2C transforms
       call c2c_1m_x_plan(c2c_x, ph)

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -616,7 +616,7 @@ module decomp_2d_fft
       complex(mytype), dimension(:, :, :), intent(IN) :: in_c
       real(mytype), dimension(:, :, :), intent(OUT) :: out_r
 
-      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
+      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -660,16 +660,15 @@ module decomp_2d_fft
 #endif
 
          ! ===== Swap Y --> X =====
-         allocate (wk3(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
 #ifdef OVERWRITE
-         call transpose_y_to_x(wk2_r2c, wk3, sp)
+         call transpose_y_to_x(wk2_r2c, wk13, sp)
 #else
-         call transpose_y_to_x(wk2b, wk3, sp)
+         call transpose_y_to_x(wk2b, wk13, sp)
 #endif
 
          ! ===== 1D FFTs in X =====
          !       status = DftiComputeBackward(c2r_x, wk3(:,1,1), out_r(:,1,1))
-         status = wrapper_c2r(c2r_x, wk3, out_r)
+         status = wrapper_c2r(c2r_x, wk13, out_r)
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2r")
 
       else if (format == PHYSICAL_IN_Z) then
@@ -707,16 +706,15 @@ module decomp_2d_fft
 #endif
 
          ! ===== Swap Y --> Z =====
-         allocate (wk3(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
 #ifdef OVERWRITE
-         call transpose_y_to_z(wk2_r2c, wk3, sp)
+         call transpose_y_to_z(wk2_r2c, wk13, sp)
 #else
-         call transpose_y_to_z(wk2b, wk3, sp)
+         call transpose_y_to_z(wk2b, wk13, sp)
 #endif
 
          ! ===== 1D FFTs in Z =====
          !       status = DftiComputeBackward(c2r_z, wk3(:,1,1), out_r(:,1,1))
-         status = wrapper_c2r(c2r_z, wk3, out_r)
+         status = wrapper_c2r(c2r_z, wk13, out_r)
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2r")
 
       end if

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -94,7 +94,11 @@ module decomp_2d_fft
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
                             decomp%xsz(2)*decomp%xsz(3))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
+#ifdef OVERWRITE
+      status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_INPLACE)
+#else
       status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_NOT_INPLACE)
+#endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_INPUT_DISTANCE, decomp%xsz(1))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
@@ -127,7 +131,11 @@ module decomp_2d_fft
                                     DFTI_COMPLEX, 1, decomp%ysz(2))
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiCreateDescriptor")
+#ifdef OVERWRITE
+      status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_INPLACE)
+#else
       status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_NOT_INPLACE)
+#endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, decomp%ysz(1))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
@@ -165,7 +173,11 @@ module decomp_2d_fft
                                     DFTI_COMPLEX, 1, decomp%zsz(3))
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiCreateDescriptor")
+#ifdef OVERWRITE
+      status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_INPLACE)
+#else
       status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_NOT_INPLACE)
+#endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
                             decomp%zsz(1)*decomp%zsz(2))
@@ -348,20 +360,34 @@ module decomp_2d_fft
           format == PHYSICAL_IN_Z .AND. isign == DECOMP_2D_FFT_BACKWARD) then
 
          ! ===== 1D FFTs in X =====
-         allocate (wk1(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
          !       if (isign==DECOMP_2D_FFT_FORWARD) then
          !          status = DftiComputeForward(c2c_x, in(:,1,1), wk1(:,1,1))
          !       else if (isign==DECOMP_2D_FFT_BACKWARD) then
          !          status = DftiComputeBackward(c2c_x, in(:,1,1), wk1(:,1,1))
          !       end if
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_x, in, isign)
+#else
+         allocate (wk1(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
          status = wrapper_c2c(c2c_x, in, wk1, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap X --> Y =====
          allocate (wk2(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
+#ifdef OVERWRITE
+         call transpose_x_to_y(in, wk2, ph)
+#else
          call transpose_x_to_y(wk1, wk2, ph)
+#endif
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, ph%xsz(3)
+            status = wrapper_c2c_inplace(c2c_y, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
          do k = 1, ph%xsz(3) ! one Z-plane at a time
             !          if (isign==DECOMP_2D_FFT_FORWARD) then
@@ -372,10 +398,15 @@ module decomp_2d_fft
             status = wrapper_c2c(c2c_y, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> Z =====
+#ifdef OVERWRITE
+         call transpose_y_to_z(wk2, out, ph)
+#else
          allocate (wk3(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
          call transpose_y_to_z(wk2b, wk3, ph)
+#endif
 
          ! ===== 1D FFTs in Z =====
          !       if (isign==DECOMP_2D_FFT_FORWARD) then
@@ -383,7 +414,11 @@ module decomp_2d_fft
          !       else if (isign==DECOMP_2D_FFT_BACKWARD) then
          !          status = DftiComputeBackward(c2c_z, wk3(:,1,1), out(:,1,1))
          !       end if
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_z, out, isign)
+#else
          status = wrapper_c2c(c2c_z, wk3, out, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
       else if (format == PHYSICAL_IN_X .AND. isign == DECOMP_2D_FFT_BACKWARD &
@@ -391,20 +426,34 @@ module decomp_2d_fft
                format == PHYSICAL_IN_Z .AND. isign == DECOMP_2D_FFT_FORWARD) then
 
          ! ===== 1D FFTs in Z =====
-         allocate (wk1(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
          !       if (isign==DECOMP_2D_FFT_FORWARD) then
          !          status = DftiComputeForward(c2c_z, in(:,1,1), wk1(:,1,1))
          !       else if (isign==DECOMP_2D_FFT_BACKWARD) then
          !          status = DftiComputeBackward(c2c_z, in(:,1,1), wk1(:,1,1))
          !       end if
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_z, in, isign)
+#else
+         allocate (wk1(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
          status = wrapper_c2c(c2c_z, in, wk1, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap Z --> Y =====
          allocate (wk2(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
+#ifdef OVERWRITE
+         call transpose_z_to_y(in, wk2, ph)
+#else
          call transpose_z_to_y(wk1, wk2, ph)
+#endif
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, ph%xsz(3)
+            status = wrapper_c2c_inplace(c2c_y, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(ph%ysz(1), ph%ysz(2), ph%ysz(3)))
          do k = 1, ph%xsz(3) ! one Z-plane at a time
             !          if (isign==DECOMP_2D_FFT_FORWARD) then
@@ -415,10 +464,15 @@ module decomp_2d_fft
             status = wrapper_c2c(c2c_y, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> X =====
+#ifdef OVERWRITE
+         call transpose_y_to_x(wk2, out, ph)
+#else
          allocate (wk3(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
          call transpose_y_to_x(wk2b, wk3, ph)
+#endif
 
          ! ===== 1D FFTs in X =====
          !       if (isign==DECOMP_2D_FFT_FORWARD) then
@@ -426,7 +480,11 @@ module decomp_2d_fft
          !       else if (isign==DECOMP_2D_FFT_BACKWARD) then
          !          status = DftiComputeBackward(c2c_x, wk3(:,1,1), out(:,1,1))
          !       end if
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_x, out, isign)
+#else
          status = wrapper_c2c(c2c_x, wk3, out, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
       end if
@@ -470,20 +528,35 @@ module decomp_2d_fft
          call transpose_x_to_y(wk1, wk2, sp)
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, sp%ysz(3)
+            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeForward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
             status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> Z =====
+#ifdef OVERWRITE
+         call transpose_y_to_z(wk2, out_c, sp)
+#else
          allocate (wk3(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
          call transpose_y_to_z(wk2b, wk3, sp)
+#endif
 
          ! ===== 1D FFTs in Z =====
          !       status = DftiComputeForward(c2c_z2, wk3(:,1,1), out_c(:,1,1))
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_z2, out_c, isign)
+#else
          status = wrapper_c2c(c2c_z2, wk3, out_c, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
       else if (format == PHYSICAL_IN_Z) then
@@ -499,20 +572,35 @@ module decomp_2d_fft
          call transpose_z_to_y(wk1, wk2, sp)
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, sp%ysz(3)
+            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeForward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
             status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> X =====
+#ifdef OVERWRITE
+         call transpose_y_to_x(wk2, out_c, sp)
+#else
          allocate (wk3(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
          call transpose_y_to_x(wk2b, wk3, sp)
+#endif
 
          ! ===== 1D FFTs in X =====
          !       status = DftiComputeForward(c2c_x2, wk3(:,1,1), out_c(:,1,1))
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_x2, out_c, isign)
+#else
          status = wrapper_c2c(c2c_x2, wk3, out_c, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
       end if
@@ -546,26 +634,45 @@ module decomp_2d_fft
       if (format == PHYSICAL_IN_X) then
 
          ! ===== 1D FFTs in Z =====
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_z2, in_c, isign)
+#else
          allocate (wk1(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
          !       status = DftiComputeBackward(c2c_z2, in_c(:,1,1), wk1(:,1,1))
          status = wrapper_c2c(c2c_z2, in_c, wk1, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap Z --> Y =====
          allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
+#ifdef OVERWRITE
+         call transpose_z_to_y(in_c, wk2, sp)
+#else
          call transpose_z_to_y(wk1, wk2, sp)
+#endif
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, sp%ysz(3)
+            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeBackward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
             status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> X =====
          allocate (wk3(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
+#ifdef OVERWRITE
+         call transpose_y_to_x(wk2, wk3, sp)
+#else
          call transpose_y_to_x(wk2b, wk3, sp)
+#endif
 
          ! ===== 1D FFTs in X =====
          !       status = DftiComputeBackward(c2r_x, wk3(:,1,1), out_r(:,1,1))
@@ -575,26 +682,45 @@ module decomp_2d_fft
       else if (format == PHYSICAL_IN_Z) then
 
          ! ===== 1D FFTs in X =====
+#ifdef OVERWRITE
+         status = wrapper_c2c_inplace(c2c_x2, in_c, isign)
+#else
          allocate (wk1(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
          !       status = DftiComputeBackward(c2c_x2, in_c(:,1,1), wk1(:,1,1))
          status = wrapper_c2c(c2c_x2, in_c, wk1, isign)
+#endif
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap X --> Y =====
          allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
+#ifdef OVERWRITE
+         call transpose_x_to_y(in_c, wk2, sp)
+#else
          call transpose_x_to_y(wk1, wk2, sp)
+#endif
 
          ! ===== 1D FFTs in Y =====
+#ifdef OVERWRITE
+         do k = 1, sp%ysz(3)
+            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
+         end do
+#else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeBackward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
             status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
+#endif
 
          ! ===== Swap Y --> Z =====
          allocate (wk3(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
+#ifdef OVERWRITE
+         call transpose_y_to_z(wk2, wk3, sp)
+#else
          call transpose_y_to_z(wk2b, wk3, sp)
+#endif
 
          ! ===== 1D FFTs in Z =====
          !       status = DftiComputeBackward(c2r_z, wk3(:,1,1), out_r(:,1,1))
@@ -642,6 +768,27 @@ module decomp_2d_fft
 
       return
    end function wrapper_c2c
+
+#ifdef OVERWRITE
+   integer function wrapper_c2c_inplace(desc, inout, isign)
+
+      implicit none
+
+      type(DFTI_DESCRIPTOR), pointer :: desc
+      complex(mytype), dimension(*) :: inout
+      integer :: isign, status
+
+      if (isign == DECOMP_2D_FFT_FORWARD) then
+         status = DftiComputeForward(desc, inout)
+      else if (isign == DECOMP_2D_FFT_BACKWARD) then
+         status = DftiComputeBackward(desc, inout)
+      end if
+
+      wrapper_c2c = status
+
+      return
+   end function wrapper_c2c_inplace
+#endif
 
    integer function wrapper_r2c(desc, in, out)
 

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -349,7 +349,9 @@ module decomp_2d_fft
       complex(mytype), dimension(:, :, :), intent(OUT) :: out
       integer, intent(IN) :: isign
 
+#ifndef OVERWRITE
       complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
+#endif
       integer :: k, status
 
 #ifdef PROFILER
@@ -487,6 +489,12 @@ module decomp_2d_fft
 
       end if
 
+      ! Free memory
+#ifndef OVERWRITE
+      deallocate(wk1, wk2b, wk3)
+#endif
+
+
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_c2c")
 #endif
@@ -504,7 +512,9 @@ module decomp_2d_fft
       real(mytype), dimension(:, :, :), intent(IN) :: in_r
       complex(mytype), dimension(:, :, :), intent(OUT) :: out_c
 
+#ifndef OVERWRITE
       complex(mytype), allocatable, dimension(:, :, :) :: wk2b, wk3
+#endif
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -599,6 +609,11 @@ module decomp_2d_fft
 
       end if
 
+      ! Free memory
+#ifndef OVERWRITE
+      deallocate(wk2b, wk3)
+#endif
+
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_r2c")
 #endif
@@ -616,7 +631,9 @@ module decomp_2d_fft
       complex(mytype), dimension(:, :, :), intent(IN) :: in_c
       real(mytype), dimension(:, :, :), intent(OUT) :: out_r
 
+#ifndef OVERWRITE
       complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b
+#endif
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -718,6 +735,11 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2r")
 
       end if
+
+      ! Free memory
+#ifndef OVERWRITE
+      deallocate(wk1, wk2b)
+#endif
 
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_c2r")

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -502,9 +502,8 @@ module decomp_2d_fft
 
       ! Free memory
 #ifndef OVERWRITE
-      deallocate(wk1, wk2b, wk3)
+      deallocate (wk1, wk2b, wk3)
 #endif
-
 
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_c2c")
@@ -622,7 +621,7 @@ module decomp_2d_fft
 
       ! Free memory
 #ifndef OVERWRITE
-      deallocate(wk2b, wk3)
+      deallocate (wk2b, wk3)
 #endif
 
 #ifdef PROFILER
@@ -749,7 +748,7 @@ module decomp_2d_fft
 
       ! Free memory
 #ifndef OVERWRITE
-      deallocate(wk1, wk2b)
+      deallocate (wk1, wk2b)
 #endif
 
 #ifdef PROFILER

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -504,7 +504,7 @@ module decomp_2d_fft
       real(mytype), dimension(:, :, :), intent(IN) :: in_r
       complex(mytype), dimension(:, :, :), intent(OUT) :: out_c
 
-      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
+      complex(mytype), allocatable, dimension(:, :, :) :: wk2b, wk3
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -516,13 +516,12 @@ module decomp_2d_fft
       if (format == PHYSICAL_IN_X) then
 
          ! ===== 1D FFTs in X =====
-         allocate (wk1(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
          !       status = DftiComputeForward(r2c_x, in_r(:,1,1), wk1(:,1,1))
-         status = wrapper_r2c(r2c_x, in_r, wk1)
+         status = wrapper_r2c(r2c_x, in_r, wk13)
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_r2c")
 
          ! ===== Swap X --> Y =====
-         call transpose_x_to_y(wk1, wk2_r2c, sp)
+         call transpose_x_to_y(wk13, wk2_r2c, sp)
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
@@ -559,13 +558,12 @@ module decomp_2d_fft
       else if (format == PHYSICAL_IN_Z) then
 
          ! ===== 1D FFTs in Z =====
-         allocate (wk1(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
          !       status = DftiComputeForward(r2c_z, in_r(:,1,1), wk1(:,1,1))
-         status = wrapper_r2c(r2c_z, in_r, wk1)
+         status = wrapper_r2c(r2c_z, in_r, wk13)
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_r2c")
 
          ! ===== Swap Z --> Y =====
-         call transpose_z_to_y(wk1, wk2_r2c, sp)
+         call transpose_z_to_y(wk13, wk2_r2c, sp)
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -618,7 +618,7 @@ module decomp_2d_fft
       complex(mytype), dimension(:, :, :), intent(IN) :: in_c
       real(mytype), dimension(:, :, :), intent(OUT) :: out_r
 
-      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2, wk2b, wk3
+      complex(mytype), allocatable, dimension(:, :, :) :: wk1, wk2b, wk3
       integer :: k, status, isign
 
 #ifdef PROFILER
@@ -640,24 +640,23 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap Z --> Y =====
-         allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
 #ifdef OVERWRITE
-         call transpose_z_to_y(in_c, wk2, sp)
+         call transpose_z_to_y(in_c, wk2_r2c, sp)
 #else
-         call transpose_z_to_y(wk1, wk2, sp)
+         call transpose_z_to_y(wk1, wk2_r2c, sp)
 #endif
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, sp%ysz(3)
-            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y2, wk2_r2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeBackward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
-            status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y2, wk2_r2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
@@ -665,7 +664,7 @@ module decomp_2d_fft
          ! ===== Swap Y --> X =====
          allocate (wk3(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
 #ifdef OVERWRITE
-         call transpose_y_to_x(wk2, wk3, sp)
+         call transpose_y_to_x(wk2_r2c, wk3, sp)
 #else
          call transpose_y_to_x(wk2b, wk3, sp)
 #endif
@@ -688,24 +687,23 @@ module decomp_2d_fft
          if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
 
          ! ===== Swap X --> Y =====
-         allocate (wk2(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
 #ifdef OVERWRITE
-         call transpose_x_to_y(in_c, wk2, sp)
+         call transpose_x_to_y(in_c, wk2_r2c, sp)
 #else
-         call transpose_x_to_y(wk1, wk2, sp)
+         call transpose_x_to_y(wk1, wk2_r2c, sp)
 #endif
 
          ! ===== 1D FFTs in Y =====
 #ifdef OVERWRITE
          do k = 1, sp%ysz(3)
-            status = wrapper_c2c_inplace(c2c_y2, wk2(1, 1, k), isign)
+            status = wrapper_c2c_inplace(c2c_y2, wk2_r2c(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #else
          allocate (wk2b(sp%ysz(1), sp%ysz(2), sp%ysz(3)))
          do k = 1, sp%ysz(3)
             !          status = DftiComputeBackward(c2c_y2, wk2(:,1,k), wk2b(:,1,k))
-            status = wrapper_c2c(c2c_y2, wk2(1, 1, k), wk2b(1, 1, k), isign)
+            status = wrapper_c2c(c2c_y2, wk2_r2c(1, 1, k), wk2b(1, 1, k), isign)
             if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "wrapper_c2c")
          end do
 #endif
@@ -713,7 +711,7 @@ module decomp_2d_fft
          ! ===== Swap Y --> Z =====
          allocate (wk3(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
 #ifdef OVERWRITE
-         call transpose_y_to_z(wk2, wk3, sp)
+         call transpose_y_to_z(wk2_r2c, wk3, sp)
 #else
          call transpose_y_to_z(wk2b, wk3, sp)
 #endif


### PR DESCRIPTION
Add support for the overwrite preprocessor variable to the MKL FFT backend. The following performance was measured for a serial run on a 128x128x128 grid using the available examples : 

<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">

<html>
<head>
	
	
</head>

<body>


  |   | x_c2c |   | x_r2c |   | z_c2c |   | z_r2c |  
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
time (sec) | master | 1.491651084 | 1.362318515 | 0.831514729 | 0.803822179 | 1.392889503 | 1.385034793 | 0.982878584 | 0.97138917
  | mkl_inplace | 1.331018543 | 1.25074677 | 0.665392137 | 0.643411227 | 1.30402926 | 1.275790235 | 0.887303425 | 0.895311678
  | mkl_inplace+overwrite | 0.805920441 | 0.767969895 | 0.427547905 | 0.442008324 | 0.800845234 | 0.765677335 | 0.668759219 | 0.635879963
  |   |   |   |   |   |   |   |   |  
ratio | master | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 1
  | mkl_inplace | 0.892312255377277 | 0.918101571863317 | 0.800216897901757 | 0.800439753728169 | 0.936204384620163 | 0.921125044257282 | 0.902759953715707 | 0.921681758094956
  | mkl_inplace+overwrite | 0.540287503991114 | 0.563722717223732 | 0.514179593083311 | 0.549883214904425 | 0.57495245119957 | 0.552821733338218 | 0.680408780785888 | 0.654608865981077


</body>

</html>

ifort (IFORT) 19.1.3.304 20200925
OpenMPI 4.1.1
