### PR TITLE
Update fft (part 2)

### DIFF
--- a/Makefile.compilers
+++ b/Makefile.compilers
@@ -84,12 +84,18 @@ else ifeq ($(CMP),nvhpc)
      LFLAGS += -acc -lnvhpcwrapnvtx
   else ifeq ($(PARAMOD),gpu)
      CCXY=80
-     NCCL=no     
+     MANAGED=yes
+     ifeq ($(MANAGED),yes)
+       GPUOPT=-gpu=cc${CCXY},managed,lineinfo
+     else
+       GPUOPT=-gpu=cc${CCXY},lineinfo
+     endif
      FFLAGS += -D_GPU
+     NCCL=no     
      ifeq ($(NCCL),yes)
        FFLAGS += -D_NCCL
      endif
-     FFLAGS += -Mfree -Kieee -Minfo=accel,stdpar -stdpar=gpu -gpu=cc${CCXY},managed,lineinfo -acc -target=gpu -traceback -O3 -DUSE_CUDA -cuda 
+     FFLAGS += -Mfree -Kieee -Minfo=accel,stdpar ${GPUOPT} -acc -target=gpu -traceback -O3 -DUSE_CUDA -cuda 
      ifeq ($(NCCL),yes)
        FFLAGS += -cudalib=cufft,nccl
      else

--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ The external code can use the named variables to check the FFT backend used in a
 
 ### OVERWRITE flag
 
-- The generic backend does not support the OVERWRITE flag
-- The FFTW3 and FFTW3_F03 backends support the OVERWRITE flag for c2c and c2r transforms
-- The oneMKL backend supports the OVERWRITE flag for c2c and c2r transforms
-- The cuFFT backend supports the OVERWRITE flag for c2c anc c2r transforms
+- The generic backend supports the OVERWRITE flag but it can not perform in-place transforms
+- The FFTW3 and FFTW3_F03 backends support the OVERWRITE flag and can perform in-place complex 1D fft
+- The oneMKL backend supports the OVERWRITE flag and can perform in-place complex 1D fft
+- The cuFFT backend supports the OVERWRITE flag but it can not perform in-place transforms
 
 ## Miscellaneous
 
@@ -133,7 +133,7 @@ This preprocessor variable is not valid for GPU builds. It leads to padded allto
 
 #### OVERWRITE
 
-This variable leads to overwrite the input array when computing FFT. The support of this flag is variable, depending on the FFT backend selected, as described above.
+This variable leads to overwrite the input array when computing FFT. The support of this flag does not always correspond to in-place transforms, depending on the FFT backend selected, as described above.
 
 #### HALO_DEBUG
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
-.PHONY: init_test test2d fft_physical_x fft_physical_z io_test 
+.PHONY: init_test test2d fft_physical_x fft_physical_z io_test halo_test
 
 # Just build the examples
-examples: init_test test2d fft_physical_x fft_physical_z io_test
+examples: init_test test2d fft_physical_x fft_physical_z io_test halo_test
 	@echo "Built the examples"
 
 init_test:
@@ -14,6 +14,8 @@ fft_physical_z:
 	$(MAKE) -C $@ all
 io_test:
 	$(MAKE) -C $@ all
+halo_test:
+	$(MAKE) -C $@ all
 
 check:
 	cd init_test; $(MAKE) $@
@@ -21,6 +23,7 @@ check:
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
 	cd io_test; $(MAKE) $@
+	cd halo_test; $(MAKE) $@
 
 clean:
 	cd init_test; $(MAKE) $@
@@ -28,5 +31,6 @@ clean:
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
 	cd io_test; $(MAKE) $@
+	cd halo_test; $(MAKE) $@
 
 export

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,36 +1,28 @@
-.PHONY: test2d fft_physical_x fft_physical_z halo_test init_test io_test 
+.PHONY: init_test test2d fft_physical_x fft_physical_z 
 
 # Just build the examples
-examples: test2d fft_physical_x fft_physical_z halo_test init_test io_test
+examples: init_test test2d fft_physical_x fft_physical_z 
 	@echo "Built the examples"
 
+init_test:
+	$(MAKE) -C $@ all
 test2d:
 	$(MAKE) -C $@ $@
 fft_physical_x:
 	$(MAKE) -C $@ all
 fft_physical_z:
 	$(MAKE) -C $@ all
-halo_test:
-	$(MAKE) -C $@ $@
-init_test:
-	$(MAKE) -C $@ all
-io_test:
-	$(MAKE) -C $@ all
 
 check:
+	cd init_test; $(MAKE) $@
 	cd test2d; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
-	cd halo_test; $(MAKE) $@
-	cd init_test; $(MAKE) $@
-	cd io_test; $(MAKE) $@
 
 clean:
+	cd init_test; $(MAKE) $@
 	cd test2d; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
-	cd halo_test; $(MAKE) $@
-	cd init_test; $(MAKE) $@
-	cd io_test; $(MAKE) $@
 
 export

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
-.PHONY: init_test test2d fft_physical_x fft_physical_z 
+.PHONY: init_test test2d fft_physical_x fft_physical_z io_test 
 
 # Just build the examples
-examples: init_test test2d fft_physical_x fft_physical_z 
+examples: init_test test2d fft_physical_x fft_physical_z io_test
 	@echo "Built the examples"
 
 init_test:
@@ -12,17 +12,21 @@ fft_physical_x:
 	$(MAKE) -C $@ all
 fft_physical_z:
 	$(MAKE) -C $@ all
+io_test:
+	$(MAKE) -C $@ all
 
 check:
 	cd init_test; $(MAKE) $@
 	cd test2d; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
+	cd io_test; $(MAKE) $@
 
 clean:
 	cd init_test; $(MAKE) $@
 	cd test2d; $(MAKE) $@
 	cd fft_physical_x; $(MAKE) $@
 	cd fft_physical_z; $(MAKE) $@
+	cd io_test; $(MAKE) $@
 
 export

--- a/examples/fft_physical_x/fft_c2c_x.f90
+++ b/examples/fft_physical_x/fft_c2c_x.f90
@@ -61,6 +61,7 @@ program fft_c2c_x
 
    t2 = 0._mytype
    t4 = 0._mytype
+  !$acc data copyin(in,xstart,xend) copy(out)
    do m = 1, ntest
 
       ! forward FFT
@@ -92,6 +93,7 @@ program fft_c2c_x
 
    ! checking accuracy
    error = 0._mytype
+   !$acc parallel loop default(present) reduction(+:error)
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
@@ -104,6 +106,7 @@ program fft_c2c_x
          end do
       end do
    end do
+   !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
    err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
 
@@ -120,6 +123,7 @@ program fft_c2c_x
       flops = 2._mytype*flops/((t1 + t3)/real(NTEST, mytype))
       write (*, *) 'GFLOPS : ', flops/1000._mytype**3
    end if
+  !$acc end data
 
    deallocate (in, out)
    nullify (ph)

--- a/examples/fft_physical_x/fft_grid_x.f90
+++ b/examples/fft_physical_x/fft_grid_x.f90
@@ -25,6 +25,8 @@ program fft_physical_x
 
    real(mytype) :: dr, di, error, err_all, n1, flops
    integer :: ierror, i, j, k, m
+   integer :: xst1, xst2, xst3
+   integer :: xen1, xen2, xen3
    real(mytype) :: t1, t2, t3, t4
 
    call MPI_INIT(ierror)
@@ -47,10 +49,15 @@ program fft_physical_x
    ! output is Z-pencil data
    call alloc_x(in, ph, .true.)
    call alloc_z(out, ph, .true.)
+   ! Convert pointers to loops start/end to scalar
+   ! This is define loop on GPUs
+   xst1 = ph%xst(1); xen1=ph%xen(1);
+   xst2 = ph%xst(2); xen2=ph%xen(2);
+   xst3 = ph%xst(3); xen3=ph%xen(3);
    ! initilise input
-   do k = ph%xst(3), ph%xen(3)
-      do j = ph%xst(2), ph%xen(2)
-         do i = ph%xst(1), ph%xen(1)
+   do k=xst3,xen3
+      do j=xst2,xen2
+         do i=xst1,xen1
             dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
                  /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
             di = dr
@@ -61,6 +68,7 @@ program fft_physical_x
 
    t2 = 0._mytype
    t4 = 0._mytype
+   !$acc data copyin(in) copy(out)
    do m = 1, ntest
 
       ! forward FFT
@@ -92,9 +100,10 @@ program fft_physical_x
 
    ! checking accuracy
    error = 0._mytype
-   do k = ph%xst(3), ph%xen(3)
-      do j = ph%xst(2), ph%xen(2)
-         do i = ph%xst(1), ph%xen(1)
+  !$acc parallel loop default(present) reduction(+:error)
+   do k=xst3,xen3
+      do j=xst2,xen2
+         do i=xst1,xen1
             dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
                  /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
             di = dr
@@ -104,6 +113,7 @@ program fft_physical_x
          end do
       end do
    end do
+   !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
    err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
 
@@ -120,6 +130,7 @@ program fft_physical_x
       flops = 2._mytype*flops/((t1 + t3)/real(NTEST, mytype))
       write (*, *) 'GFLOPS : ', flops/1000._mytype**3
    end if
+  !$acc end data
 
    deallocate (in, out)
    nullify (ph)

--- a/examples/fft_physical_x/fft_r2c_x.f90
+++ b/examples/fft_physical_x/fft_r2c_x.f90
@@ -62,6 +62,7 @@ program fft_r2c_x
 
    t2 = 0._mytype
    t4 = 0._mytype
+   !$acc data copyin(in_r,xstart,xend) copy(out)
    do m = 1, ntest
 
       ! 3D r2c FFT
@@ -93,6 +94,7 @@ program fft_r2c_x
 
    ! checking accuracy
    error = 0._mytype
+   !$acc parallel loop default(present) reduction(+:error)
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
@@ -102,6 +104,7 @@ program fft_r2c_x
          end do
       end do
    end do
+   !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
    err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
 
@@ -110,6 +113,7 @@ program fft_r2c_x
       write (*, *) 'error / mesh point: ', err_all
       write (*, *) 'time (sec): ', t1, t3
    end if
+   !$acc end data
 
    deallocate (in_r, out)
    nullify (ph)

--- a/examples/fft_physical_z/fft_r2c_z.f90
+++ b/examples/fft_physical_z/fft_r2c_z.f90
@@ -63,6 +63,7 @@ program fft_r2c_z
 
    t2 = 0._mytype
    t4 = 0._mytype
+   !$acc data copyin(in_r,zstart,zend) copy(out)
    do m = 1, ntest
 
       ! 3D r2c FFT
@@ -93,6 +94,7 @@ program fft_r2c_z
 
    ! checking accuracy
    error = 0._mytype
+   !$acc parallel loop default(present) reduction(+:error)
    do k = zstart(3), zend(3)
       do j = zstart(2), zend(2)
          do i = zstart(1), zend(1)
@@ -103,6 +105,7 @@ program fft_r2c_z
          end do
       end do
    end do
+   !$acc end loop
 !10 format('in_r final ', I2,1x,I2,1x,I2,1x,I2,1x,F12.6,1x,F12.6)
 
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
@@ -113,6 +116,7 @@ program fft_r2c_z
       write (*, *) 'error / mesh point: ', err_all
       write (*, *) 'time (sec): ', t1, t3
    end if
+  !$acc end data
 
    deallocate (in_r, out)
    nullify(ph)

--- a/examples/halo_test/Makefile
+++ b/examples/halo_test/Makefile
@@ -10,12 +10,15 @@ OBJ = halo_test.o
 NP ?= 1
 MPIRUN ?= mpirun
 
+all: halo_test
+
 halo_test: $(OBJ)
 	$(FC) $(FFLAGS) $(OPT) $(DEFS) $(INC) -o $@ $(OBJ) $(LIBS)
 
 ifeq ($(PARAMOD),gpu)
 check:
-	$(MPIRUN) -n $(NP) ./bind.sh ./halo_test
+	$(info Halo test temporarily disabled for GPU)
+#	$(MPIRUN) -n $(NP) ./bind.sh ./halo_test
 else
 check:
 	$(MPIRUN) -n $(NP) ./halo_test

--- a/examples/halo_test/halo_test.f90
+++ b/examples/halo_test/halo_test.f90
@@ -110,25 +110,25 @@ contains
 #else
       logical, parameter :: global = .false.
 #endif
-      integer :: i1, in ! I loop start/end
-      integer :: j1, jn ! J loop start/end
-      integer :: k1, kn ! K loop start/end
+      integer :: ifirst, ilast ! I loop start/end
+      integer :: jfirst, jlast ! J loop start/end
+      integer :: kfirst, klast ! K loop start/end
 
       ! du/dx calculated on X-pencil
       call alloc_x(div1, global)
 #ifdef HALO_GLOBAL
-      k1 = xstart(3); kn = xend(3)
-      j1 = xstart(2); jn = xend(2)
+      kfirst = xstart(3); klast = xend(3)
+      jfirst = xstart(2); jlast = xend(2)
 #else
-      k1 = 1; kn = xsize(3)
-      j1 = 1; jn = xsize(2)
+      kfirst = 1; klast = xsize(3)
+      jfirst = 1; jlast = xsize(2)
 #endif
-      i1 = 2; in = xsize(1) - 1
+      ifirst = 2; ilast = xsize(1) - 1
 
       div1 = 0.0_mytype
-      do k = k1, kn
-         do j = j1, jn
-            do i = i1, in
+      do k = kfirst, klast
+         do j = jfirst, jlast
+            do i = ifirst, ilast
                div1(i, j, k) = u1(i + 1, j, k) - u1(i - 1, j, k)
             end do
          end do
@@ -138,20 +138,20 @@ contains
       call alloc_y(v2, global)
       call alloc_y(wk2, global)
 #ifdef HALO_GLOBAL
-      k1 = ystart(3); kn = yend(3)
-      i1 = ystart(1); in = yend(1)
+      kfirst = ystart(3); klast = yend(3)
+      ifirst = ystart(1); ilast = yend(1)
 #else
-      k1 = 1; kn = ysize(3)
-      i1 = 1; in = ysize(1)
+      kfirst = 1; klast = ysize(3)
+      ifirst = 1; ilast = ysize(1)
 #endif
-      j1 = 2; jn = ysize(2) - 1
+      jfirst = 2; jlast = ysize(2) - 1
 
       call transpose_x_to_y(v1, v2)
       call transpose_x_to_y(div1, wk2)
 
-      do k = k1, kn
-         do j = j1, jn
-            do i = i1, in
+      do k = kfirst, klast
+         do j = jfirst, jlast
+            do i = ifirst, ilast
                wk2(i, j, k) = wk2(i, j, k) + v2(i, j + 1, k) - v2(i, j - 1, k)
             end do
          end do
@@ -162,21 +162,21 @@ contains
       call alloc_z(w3, global)
       call alloc_z(wk3, global)
 #ifdef HALO_GLOBAL
-      j1 = zstart(2); jn = zend(2)
-      i1 = zstart(1); in = zend(1)
+      jfirst = zstart(2); jlast = zend(2)
+      ifirst = zstart(1); ilast = zend(1)
 #else
-      j1 = 1; jn = zsize(2)
-      i1 = 1; in = zsize(1)
+      jfirst = 1; jlast = zsize(2)
+      ifirst = 1; ilast = zsize(1)
 #endif
-      k1 = 2; kn = zsize(3) - 1
+      kfirst = 2; klast = zsize(3) - 1
 
       call transpose_x_to_y(w1, w2)
       call transpose_y_to_z(w2, w3)
       call transpose_y_to_z(wk2, wk3)
 
-      do k = k1, kn
-         do j = j1, jn
-            do i = i1, in
+      do k = kfirst, klast
+         do j = jfirst, jlast
+            do i = ifirst, ilast
                wk3(i, j, k) = wk3(i, j, k) + w3(i, j, k + 1) - w3(i, j, k - 1)
             end do
          end do
@@ -209,9 +209,9 @@ contains
 #else
       logical, parameter :: global = .false.
 #endif
-      integer :: i1, in ! I loop start/end
-      integer :: j1, jn ! J loop start/end
-      integer :: k1, kn ! K loop start/end
+      integer :: ifirst, ilast ! I loop start/end
+      integer :: jfirst, jlast ! J loop start/end
+      integer :: kfirst, klast ! K loop start/end
 
       ! Expected sizes
       nx_expected = nx
@@ -223,24 +223,24 @@ contains
       call update_halo(v1, vh, 1, opt_global=.true., opt_pencil=1)
       call update_halo(w1, wh, 1, opt_global=.true., opt_pencil=1)
 
-      k1 = xstart(3); kn = xend(3)
-      j1 = xstart(2); jn = xend(2)
+      kfirst = xstart(3); klast = xend(3)
+      jfirst = xstart(2); jlast = xend(2)
 #else
       call update_halo(v1, vh, 1, opt_pencil=1)
       call update_halo(w1, wh, 1, opt_pencil=1)
 
-      k1 = 1; kn = xsize(3)
-      j1 = 1; jn = xsize(2)
+      kfirst = 1; klast = xsize(3)
+      jfirst = 1; jlast = xsize(2)
 #endif
-      i1 = 2; in = xsize(1) - 1
+      ifirst = 2; ilast = xsize(1) - 1
 
       call test_halo_size(vh, nx_expected, ny_expected, nz_expected, "X:v")
       call test_halo_size(wh, nx_expected, ny_expected, nz_expected, "X:w")
 
       div2 = 0.0_mytype
-      do k = k1, kn
-         do j = j1, jn
-            do i = i1, in
+      do k = kfirst, klast
+         do j = jfirst, jlast
+            do i = ifirst, ilast
                div2(i, j, k) = (u1(i + 1, j, k) - u1(i - 1, j, k)) &
                                + (vh(i, j + 1, k) - vh(i, j - 1, k)) &
                                + (wh(i, j, k + 1) - wh(i, j, k - 1))
@@ -267,9 +267,9 @@ contains
 #else
       logical, parameter :: global = .false.
 #endif
-      integer :: i1, in ! I loop start/end
-      integer :: j1, jn ! J loop start/end
-      integer :: k1, kn ! K loop start/end
+      integer :: ifirst, ilast ! I loop start/end
+      integer :: jfirst, jlast ! J loop start/end
+      integer :: kfirst, klast ! K loop start/end
 
       ! Expected sizes
       nx_expected = ysize(1) + 2
@@ -290,22 +290,22 @@ contains
 #ifdef HALO_GLOBAL
       call update_halo(u2, uh, 1, opt_global=.true., opt_pencil=2)
       call update_halo(w2, wh, 1, opt_global=.true., opt_pencil=2)
-      k1 = ystart(3); kn = yend(3)
-      i1 = ystart(1); in = yend(1)
+      kfirst = ystart(3); klast = yend(3)
+      ifirst = ystart(1); ilast = yend(1)
 #else
       call update_halo(u2, uh, 1, opt_pencil=2)
       call update_halo(w2, wh, 1, opt_pencil=2)
-      k1 = 1; kn = ysize(3)
-      i1 = 1; in = ysize(1)
+      kfirst = 1; klast = ysize(3)
+      ifirst = 1; ilast = ysize(1)
 #endif
-      j1 = 2; jn = ysize(2) - 1
+      jfirst = 2; jlast = ysize(2) - 1
 
       call test_halo_size(uh, nx_expected, ny_expected, nz_expected, "Y:u")
       call test_halo_size(wh, nx_expected, ny_expected, nz_expected, "Y:w")
 
-      do k = k1, kn
-         do j = j1, jn
-            do i = i1, in
+      do k = kfirst, klast
+         do j = jfirst, jlast
+            do i = ifirst, ilast
                wk2(i, j, k) = (uh(i + 1, j, k) - uh(i - 1, j, k)) &
                               + (v2(i, j + 1, k) - v2(i, j - 1, k)) &
                               + (wh(i, j, k + 1) - wh(i, j, k - 1))
@@ -334,9 +334,9 @@ contains
 #else
       logical, parameter :: global = .false.
 #endif
-      integer :: i1, in ! I loop start/end
-      integer :: j1, jn ! J loop start/end
-      integer :: k1, kn ! K loop start/end
+      integer :: ifirst, ilast ! I loop start/end
+      integer :: jfirst, jlast ! J loop start/end
+      integer :: kfirst, klast ! K loop start/end
 
       ! Expected sizes
       nx_expected = zsize(1) + 2
@@ -358,20 +358,20 @@ contains
       ! du/dx
 #ifdef HALO_GLOBAL
       call update_halo(u3, uh, 1, opt_global=.true., opt_pencil=3)
-      i1 = zstart(1); in = zend(1)
-      j1 = zstart(2); jn = zend(2)
+      ifirst = zstart(1); ilast = zend(1)
+      jfirst = zstart(2); jlast = zend(2)
 #else
       call update_halo(u3, uh, 1, opt_pencil=3)
-      i1 = 1; in = zsize(1)
-      j1 = 1; jn = zsize(2)
+      ifirst = 1; ilast = zsize(1)
+      jfirst = 1; jlast = zsize(2)
 #endif
-      k1 = 2; kn = zsize(3) - 1
+      kfirst = 2; klast = zsize(3) - 1
 
       call test_halo_size(uh, nx_expected, ny_expected, nz_expected, "Z:u")
 
-      do j = j1, jn
-         do i = i1, in
-            do k = k1, kn
+      do j = jfirst, jlast
+         do i = ifirst, ilast
+            do k = kfirst, klast
                wk3(i, j, k) = uh(i + 1, j, k) - uh(i - 1, j, k)
             end do
          end do
@@ -386,18 +386,18 @@ contains
 
       call test_halo_size(vh, nx_expected, ny_expected, nz_expected, "Z:v")
 
-      do j = j1, jn
-         do i = i1, in
-            do k = k1, kn
+      do j = jfirst, jlast
+         do i = ifirst, ilast
+            do k = kfirst, klast
                wk3(i, j, k) = wk3(i, j, k) + vh(i, j + 1, k) - vh(i, j - 1, k)
             end do
          end do
       end do
 
       ! dw/dz
-      do j = j1, jn
-         do i = i1, in
-            do k = k1, kn
+      do j = jfirst, jlast
+         do i = ifirst, ilast
+            do k = kfirst, klast
                wk3(i, j, k) = wk3(i, j, k) + w3(i, j, k + 1) - w3(i, j, k - 1)
             end do
          end do

--- a/examples/io_test/io_plane_test.f90
+++ b/examples/io_test/io_plane_test.f90
@@ -64,30 +64,16 @@ program io_plane_test
    !$acc update self(u3)  
    !$acc end data
  
-#if defined(_GPU)
-   write (*, *) 'WARNING for GPU IO: write of a plane is supported only in the aligned pencil'
-   write (*, *) '                    i.e. x_plane-x_pencil'
-   write (*, *) '                    i.e. y_plane-y_pencil'
-   write (*, *) '                    i.e. z_plane-z_pencil'
-#endif
-
    call decomp_2d_write_plane(1, u1, 1, nx/2, '.', 'x_pencil-x_plane.dat', 'test')
-#if !defined(_GPU)
    call decomp_2d_write_plane(1, u1, 2, ny/2, '.', 'x_pencil-y_plane.dat', 'test')
    call decomp_2d_write_plane(1, u1, 3, nz/2, '.', 'x_pencil-z_plane.dat', 'test')
-#endif
    ! Y-pencil data
    call decomp_2d_write_plane(2, u2, 2, ny/2, '.', 'y_pencil-y_plane.dat', 'test')
-#if !defined(_GPU)
    call decomp_2d_write_plane(2, u2, 1, nx/2, '.', 'y_pencil-x_plane.dat', 'test')
    call decomp_2d_write_plane(2, u2, 3, nz/2, '.', 'y_pencil-z_plane.dat', 'test')
-#endif
-
    ! Z-pencil data
-#if !defined(_GPU)
    call decomp_2d_write_plane(3, u3, 1, nx/2, '.', 'z_pencil-x_plane.dat', 'test')
    call decomp_2d_write_plane(3, u3, 2, ny/2, '.', 'z_pencil-y_plane.dat', 'test')
-#endif
    call decomp_2d_write_plane(3, u3, 3, nz/2, '.', 'z_pencil-z_plane.dat', 'test')
    ! Attemp to read the files
    if (nrank == 0) then

--- a/examples/io_test/io_plane_test.f90
+++ b/examples/io_test/io_plane_test.f90
@@ -57,15 +57,20 @@ program io_plane_test
       end do
    end do
    !$acc end loop
-   write(*,*) 'End Loop'
    call transpose_x_to_y(u1, u2)
    call transpose_y_to_z(u2, u3)
    !$acc update self(u1)  
    !$acc update self(u2)  
    !$acc update self(u3)  
    !$acc end data
-   call decomp_2d_write_one(1, u1, '.', 'u1.dat', 0, 'test')
  
+#if defined(_GPU)
+   write (*, *) 'WARNING for GPU IO: write of a plane is supported only in the aligned pencil'
+   write (*, *) '                    i.e. x_plane-x_pencil'
+   write (*, *) '                    i.e. y_plane-y_pencil'
+   write (*, *) '                    i.e. z_plane-z_pencil'
+#endif
+
    call decomp_2d_write_plane(1, u1, 1, nx/2, '.', 'x_pencil-x_plane.dat', 'test')
 #if !defined(_GPU)
    call decomp_2d_write_plane(1, u1, 2, ny/2, '.', 'x_pencil-y_plane.dat', 'test')

--- a/examples/io_test/io_test.f90
+++ b/examples/io_test/io_test.f90
@@ -86,7 +86,7 @@ program io_test
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
-            if (abs((u2(i, j, k) - u2b(i, j, k))) > eps) stop 1
+            if (abs((u1(i, j, k) - u1b(i, j, k))) > eps) stop 1
          end do
       end do
    end do

--- a/examples/io_test/io_test.f90
+++ b/examples/io_test/io_test.f90
@@ -53,6 +53,8 @@ program io_test
    call alloc_z(u3b, .true.)
 
    ! original x-pencil based data
+   !$acc data copyin(data1,xstart,xend) copy(u1,u2,u3) 
+   !$acc parallel loop default(present)
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
@@ -60,10 +62,15 @@ program io_test
          end do
       end do
    end do
+   !$acc end loop
 
    ! transpose
    call transpose_x_to_y(u1, u2)
    call transpose_y_to_z(u2, u3)
+   !$acc update self(u1)  
+   !$acc update self(u2)  
+   !$acc update self(u3)
+   !$acc end data  
 
    ! write to disk
    call decomp_2d_write_one(1, u1, '.', 'u1.dat', 0, 'test')
@@ -79,7 +86,7 @@ program io_test
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
-            if (abs((u1(i, j, k) - u1b(i, j, k))) > eps) stop 1
+            if (abs((u2(i, j, k) - u2b(i, j, k))) > eps) stop 1
          end do
       end do
    end do

--- a/examples/io_test/io_var_test.f90
+++ b/examples/io_test/io_var_test.f90
@@ -112,6 +112,8 @@ program io_var_test
    call alloc_z(u3l_b, large, .true.)
 
    ! distribute the data
+   !$acc data copyin(data1,cdata1,data1_large,xstart,xend,large%xst,large%xen) copy(u1,u2,u3,u1l,u2l,u3l,cu1,cu2,cu3) 
+   !$acc parallel loop default(present)
    do k = xstart(3), xend(3)
       do j = xstart(2), xend(2)
          do i = xstart(1), xend(1)
@@ -120,6 +122,8 @@ program io_var_test
          end do
       end do
    end do
+   !$acc end loop
+   !$acc parallel loop default(present)
    do k = large%xst(3), large%xen(3)
       do j = large%xst(2), large%xen(2)
          do i = large%xst(1), large%xen(1)
@@ -127,6 +131,7 @@ program io_var_test
          end do
       end do
    end do
+   !$acc end loop
 
    ! transpose
    call transpose_x_to_y(u1, u2)
@@ -135,6 +140,16 @@ program io_var_test
    call transpose_y_to_z(u2l, u3l, large)
    call transpose_x_to_y(cu1, cu2)
    call transpose_y_to_z(cu2, cu3)
+   !$acc update self (u1)
+   !$acc update self (u2)
+   !$acc update self (u3)
+   !$acc update self (u1l)
+   !$acc update self (u2l)
+   !$acc update self (u3l)
+   !$acc update self (cu1)
+   !$acc update self (cu2)
+   !$acc update self (cu3)
+   !$acc end data
 
    ! open file for IO
    write (filename, '(A,I3.3)') 'io_var_data.', nproc

--- a/examples/test2d/test2d.f90
+++ b/examples/test2d/test2d.f90
@@ -40,6 +40,18 @@ program test2d
       end do
    end do
 
+   ! Fill the local index
+   xst1 = xstart(1); xen1 = xend(1)
+   xst2 = xstart(2); xen2 = xend(2)
+   xst3 = xstart(3); xen3 = xend(3)
+   yst1 = ystart(1); yen1 = yend(1)
+   yst2 = ystart(2); yen2 = yend(2)
+   yst3 = ystart(3); yen3 = yend(3)
+   zst1 = zstart(1); zen1 = zend(1)
+   zst2 = zstart(2); zen2 = zend(2)
+   zst3 = zstart(3); zen3 = zend(3)
+   
+
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Testing the swap routines
    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -151,7 +163,7 @@ program test2d
    if (ierror /= 0) call decomp_2d_abort(ierror, "MPI_ALLREDUCE")
    if (error_flag) call decomp_2d_abort(3, "error swaping z->y")
 
-  !!!!!!!!!!!!!!!!!!!!!!!
+   !!!!!!!!!!!!!!!!!!!!!!!
    ! y-pensil ==> x-pensil
    call transpose_y_to_x(u2, u1)
    ! call decomp_2d_write_one(1,u1,'u1b.dat')

--- a/examples/test2d/test2d.f90
+++ b/examples/test2d/test2d.f90
@@ -61,6 +61,7 @@ program test2d
 
 #ifdef DEBUG
    if (nrank == 0) then
+      !$acc update self(u1)  
       write (*, *) 'Numbers held on Rank 0'
       write (*, *) ' '
       write (*, *) 'X-pencil'

--- a/src/fft_common.f90
+++ b/src/fft_common.f90
@@ -35,7 +35,7 @@ complex(mytype), contiguous, pointer, dimension(:, :, :) :: wk2_r2c
 complex(mytype), allocatable, dimension(:, :, :) :: wk13
 
 public :: decomp_2d_fft_init, decomp_2d_fft_3d, &
-          decomp_2d_fft_finalize, &
+          decomp_2d_fft_finalize, decomp_2d_fft_get_size, &
           decomp_2d_fft_get_ph, decomp_2d_fft_get_sp
 
 ! Declare generic interfaces to handle different inputs
@@ -214,6 +214,29 @@ subroutine decomp_2d_fft_finalize
 
    return
 end subroutine decomp_2d_fft_finalize
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Return the size, starting/ending index of the distributed array
+!  whose global size is (nx/2+1)*ny*nz, for defining data structures
+!  in r2c and c2r interfaces
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+subroutine decomp_2d_fft_get_size(istart, iend, isize)
+
+   implicit none
+   integer, dimension(3), intent(OUT) :: istart, iend, isize
+
+   if (format == PHYSICAL_IN_X) then
+      istart = sp%zst
+      iend = sp%zen
+      isize = sp%zsz
+   else if (format == PHYSICAL_IN_Z) then
+      istart = sp%xst
+      iend = sp%xen
+      isize = sp%xsz
+   end if
+
+   return
+end subroutine decomp_2d_fft_get_size
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 ! Return a pointer to the decomp_info object ph

--- a/src/fft_cufft.f90
+++ b/src/fft_cufft.f90
@@ -368,6 +368,7 @@ module decomp_2d_fft
 
       end if
 #endif
+      cufft_ws = cufft_ws / sizeof(1._mytype)
       allocate (cufft_workspace(cufft_ws))
       do j = 1, 3
          do i = -1, 2
@@ -408,24 +409,18 @@ module decomp_2d_fft
       integer, intent(IN) :: isign
       integer*4, intent(IN) :: plan1
 
-      complex(mytype), dimension(:, :, :), allocatable :: output
       integer :: istat
 
-      allocate (output, mold=inout)
 #ifdef DOUBLE_PREC
-      !$acc host_data use_device(inout,output)
-      istat = cufftExecZ2Z(plan1, inout, output, isign)
+      !$acc host_data use_device(inout)
+      istat = cufftExecZ2Z(plan1, inout, inout,isign)
       !$acc end host_data
 #else
-      !$acc host_data use_device(inout,output)
-      istat = cufftExecC2C(plan1, inout, output, isign)
+      !$acc host_data use_device(inout)
+      istat = cufftExecC2C(plan1, inout, inout,isign)
       !$acc end host_data
 #endif
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftExecC2C/Z2Z")
-      !$acc kernels
-      inout = output
-      !$acc end kernels
-      deallocate (output)
 
    end subroutine c2c_1m_x
 
@@ -438,28 +433,22 @@ module decomp_2d_fft
       integer, intent(IN) :: isign
       integer*4, intent(IN) :: plan1
 
-      complex(mytype), dimension(:, :, :), allocatable :: output
       integer :: s3, k, istat
 
-      allocate (output, mold=inout)
       ! transform on one Z-plane at a time
       s3 = size(inout, 3)
       do k = 1, s3
 #ifdef DOUBLE_PREC
-         !$acc host_data use_device(inout,output)
-         istat = cufftExecZ2Z(plan1, inout(:, :, k), output(:, :, k), isign)
-         !$acc end host_data
+        !$acc host_data use_device(inout)
+        istat = cufftExecZ2Z(plan1, inout(:,:,k), inout(:,:,k),isign)
+        !$acc end host_data
 #else
-         !$acc host_data use_device(inout,output)
-         istat = cufftExecC2C(plan1, inout(:, :, k), output(:, :, k), isign)
-         !$acc end host_data
+        !$acc host_data use_device(inout)
+        istat = cufftExecC2C(plan1, inout(:,:,k), inout(:,:,k),isign)
+        !$acc end host_data
 #endif
          if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftExecC2C/Z2Z")
       end do
-      !$acc kernels
-      inout = output
-      !$acc end kernels
-      deallocate (output)
 
    end subroutine c2c_1m_y
 
@@ -472,25 +461,19 @@ module decomp_2d_fft
       integer, intent(IN) :: isign
       integer*4, intent(IN) :: plan1
 
-      complex(mytype), dimension(:, :, :), allocatable :: output
       integer :: istat
 
-      allocate (output, mold=inout)
 
 #ifdef DOUBLE_PREC
-      !$acc host_data use_device(inout,output)
-      istat = cufftExecZ2Z(plan1, inout, output, isign)
+      !$acc host_data use_device(inout)
+      istat = cufftExecZ2Z(plan1, inout, inout,isign)
       !$acc end host_data
 #else
-      !$acc host_data use_device(inout,output)
-      istat = cufftExecC2C(plan1, inout, output, isign)
+      !$acc host_data use_device(inout)
+      istat = cufftExecC2C(plan1, inout, inout,isign)
       !$acc end host_data
 #endif
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftExecC2C/Z2Z")
-      !$acc kernels
-      inout = output
-      !$acc end kernels
-      deallocate (output)
 
    end subroutine c2c_1m_z
 
@@ -604,6 +587,7 @@ module decomp_2d_fft
       if (decomp_profiler_fft) call decomp_profiler_start("fft_c2c")
 #endif
 
+      !$acc data create(wk2_c2c) present(in,out)
       if (format == PHYSICAL_IN_X .AND. isign == DECOMP_2D_FFT_FORWARD .OR. &
           format == PHYSICAL_IN_Z .AND. isign == DECOMP_2D_FFT_BACKWARD) then
 
@@ -612,7 +596,11 @@ module decomp_2d_fft
          call c2c_1m_x(in, isign, plan(isign, 1))
 #else
          allocate (wk1(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
+         !$acc enter data create(wk1) async
+         !$acc wait
+         !$acc kernels default(present)
          wk1 = in
+         !$acc end kernels
          call c2c_1m_x(wk1, isign, plan(isign, 1))
 #endif
 
@@ -654,7 +642,11 @@ module decomp_2d_fft
          call c2c_1m_z(in, isign, plan(isign, 3))
 #else
          allocate (wk1(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
+         !$acc enter data create(wk1) async
+         !$acc wait
+         !$acc kernels default(present)
          wk1 = in
+         !$acc end kernels
          call c2c_1m_z(wk1, isign, plan(isign, 3))
 #endif
 
@@ -684,8 +676,11 @@ module decomp_2d_fft
       end if
 
 #ifndef OVERWRITE
+      !$acc exit data delete(wk1) async
+      !$acc wait 
       deallocate (wk1)
 #endif
+      !$acc end data
 
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_c2c")
@@ -709,6 +704,7 @@ module decomp_2d_fft
       if (decomp_profiler_fft) call decomp_profiler_start("fft_r2c")
 #endif
 
+      !$acc data create(wk13,wk2_r2c) present(in_r,out_c)
       if (format == PHYSICAL_IN_X) then
 
          ! ===== 1D FFTs in X =====
@@ -815,6 +811,7 @@ module decomp_2d_fft
          write (*, *)
 #endif
       end if
+      !$acc end data
 
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_r2c")
@@ -841,6 +838,7 @@ module decomp_2d_fft
       if (decomp_profiler_fft) call decomp_profiler_start("fft_c2r")
 #endif
 
+      !$acc data create(wk2_r2c,wk13) present(in_c,out_r)
       if (format == PHYSICAL_IN_X) then
 
          ! ===== 1D FFTs in Z =====
@@ -848,7 +846,11 @@ module decomp_2d_fft
          call c2c_1m_z(in_c, 1, plan(2, 3))
 #else
          allocate (wk1(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
+         !$acc enter data create(wk1) async
+         !$acc wait
+         !$acc kernels default(present)
          wk1 = in_c
+         !$acc end kernels
          call c2c_1m_z(wk1, 1, plan(2, 3))
 #endif
 
@@ -902,7 +904,11 @@ module decomp_2d_fft
 #endif
 #else
          allocate (wk1(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
+         !$acc enter data create(wk1) async
+         !$acc wait
+         !$acc kernels default(present)
          wk1 = in_c
+         !$acc end kernels
          call c2c_1m_x(wk1, 1, plan(2, 1))
 #ifdef DEBUG
          write (*, *) 'Back2 c2c_1m_x line 821'
@@ -1020,8 +1026,11 @@ module decomp_2d_fft
       end if
 
 #ifndef OVERWRITE
+      !$acc exit data delete(wk1) async
+      !$acc wait
       deallocate (wk1)
 #endif
+      !$acc end data
 
 #ifdef PROFILER
       if (decomp_profiler_fft) call decomp_profiler_end("fft_c2r")

--- a/src/fft_fftw3.f90
+++ b/src/fft_fftw3.f90
@@ -339,17 +339,12 @@ module decomp_2d_fft
    ! the basis of three-dimensional FFTs.
 
    ! c2c transform, multiple 1D FFTs in x direction
-   subroutine c2c_1m_x(inout, isign, plan1)
+   subroutine c2c_1m_x(inout, plan1)
 
       implicit none
 
       complex(mytype), dimension(:, :, :), intent(INOUT) :: inout
-      integer, intent(IN) :: isign
       type(C_PTR), intent(IN) :: plan1
-
-      integer :: foo
-
-      foo = isign ! Silence unused dummy argument
 
 #ifdef DOUBLE_PREC
       call dfftw_execute_dft(plan1, inout, inout)
@@ -361,19 +356,14 @@ module decomp_2d_fft
    end subroutine c2c_1m_x
 
    ! c2c transform, multiple 1D FFTs in y direction
-   subroutine c2c_1m_y(inout, isign, plan1)
+   subroutine c2c_1m_y(inout, plan1)
 
       implicit none
 
       complex(mytype), dimension(:, :, :), intent(INOUT) :: inout
-      integer, intent(IN) :: isign
       type(C_PTR), intent(IN) :: plan1
 
       integer :: k, s3
-
-      integer :: foo
-
-      foo = isign ! Silence unused dummy argument
 
       ! transform on one Z-plane at a time
       s3 = size(inout, 3)
@@ -389,17 +379,12 @@ module decomp_2d_fft
    end subroutine c2c_1m_y
 
    ! c2c transform, multiple 1D FFTs in z direction
-   subroutine c2c_1m_z(inout, isign, plan1)
+   subroutine c2c_1m_z(inout, plan1)
 
       implicit none
 
       complex(mytype), dimension(:, :, :), intent(INOUT) :: inout
-      integer, intent(IN) :: isign
       type(C_PTR), intent(IN) :: plan1
-
-      integer :: foo
-
-      foo = isign ! Silence unused dummy argument
 
 #ifdef DOUBLE_PREC
       call dfftw_execute_dft(plan1, inout, inout)
@@ -502,11 +487,11 @@ module decomp_2d_fft
 
          ! ===== 1D FFTs in X =====
 #ifdef OVERWRITE
-         call c2c_1m_x(in, isign, plan(isign, 1))
+         call c2c_1m_x(in, plan(isign, 1))
 #else
          allocate (wk1(ph%xsz(1), ph%xsz(2), ph%xsz(3)))
          wk1 = in
-         call c2c_1m_x(wk1, isign, plan(isign, 1))
+         call c2c_1m_x(wk1, plan(isign, 1))
 #endif
 
          ! ===== Swap X --> Y; 1D FFTs in Y =====
@@ -517,12 +502,12 @@ module decomp_2d_fft
 #else
             call transpose_x_to_y(wk1, wk2_c2c, ph)
 #endif
-            call c2c_1m_y(wk2_c2c, isign, plan(isign, 2))
+            call c2c_1m_y(wk2_c2c, plan(isign, 2))
          else
 #ifdef OVERWRITE
-            call c2c_1m_y(in, isign, plan(isign, 2))
+            call c2c_1m_y(in, plan(isign, 2))
 #else
-            call c2c_1m_y(wk1, isign, plan(isign, 2))
+            call c2c_1m_y(wk1, plan(isign, 2))
 #endif
          end if
 
@@ -536,7 +521,7 @@ module decomp_2d_fft
             call transpose_y_to_z(wk1, out, ph)
 #endif
          end if
-         call c2c_1m_z(out, isign, plan(isign, 3))
+         call c2c_1m_z(out, plan(isign, 3))
 
       else if (format == PHYSICAL_IN_X .AND. isign == DECOMP_2D_FFT_BACKWARD &
                .OR. &
@@ -544,11 +529,11 @@ module decomp_2d_fft
 
          ! ===== 1D FFTs in Z =====
 #ifdef OVERWRITE
-         call c2c_1m_z(in, isign, plan(isign, 3))
+         call c2c_1m_z(in, plan(isign, 3))
 #else
          allocate (wk1(ph%zsz(1), ph%zsz(2), ph%zsz(3)))
          wk1 = in
-         call c2c_1m_z(wk1, isign, plan(isign, 3))
+         call c2c_1m_z(wk1, plan(isign, 3))
 #endif
 
          ! ===== Swap Z --> Y; 1D FFTs in Y =====
@@ -558,21 +543,21 @@ module decomp_2d_fft
 #else
             call transpose_z_to_y(wk1, wk2_c2c, ph)
 #endif
-            call c2c_1m_y(wk2_c2c, isign, plan(isign, 2))
+            call c2c_1m_y(wk2_c2c, plan(isign, 2))
          else  ! out==wk2_c2c if 1D decomposition
 #ifdef OVERWRITE
             call transpose_z_to_y(in, out, ph)
 #else
             call transpose_z_to_y(wk1, out, ph)
 #endif
-            call c2c_1m_y(out, isign, plan(isign, 2))
+            call c2c_1m_y(out, plan(isign, 2))
          end if
 
          ! ===== Swap Y --> X; 1D FFTs in X =====
          if (dims(1) > 1) then
             call transpose_y_to_x(wk2_c2c, out, ph)
          end if
-         call c2c_1m_x(out, isign, plan(isign, 1))
+         call c2c_1m_x(out, plan(isign, 1))
 
       end if
 
@@ -601,9 +586,9 @@ module decomp_2d_fft
          ! ===== Swap X --> Y; 1D FFTs in Y =====
          if (dims(1) > 1) then
             call transpose_x_to_y(wk13, wk2_r2c, sp)
-            call c2c_1m_y(wk2_r2c, -1, plan(0, 2))
+            call c2c_1m_y(wk2_r2c, plan(0, 2))
          else
-            call c2c_1m_y(wk13, -1, plan(0, 2))
+            call c2c_1m_y(wk13, plan(0, 2))
          end if
 
          ! ===== Swap Y --> Z; 1D FFTs in Z =====
@@ -612,7 +597,7 @@ module decomp_2d_fft
          else
             call transpose_y_to_z(wk13, out_c, sp)
          end if
-         call c2c_1m_z(out_c, -1, plan(0, 3))
+         call c2c_1m_z(out_c, plan(0, 3))
 
       else if (format == PHYSICAL_IN_Z) then
 
@@ -622,17 +607,17 @@ module decomp_2d_fft
          ! ===== Swap Z --> Y; 1D FFTs in Y =====
          if (dims(1) > 1) then
             call transpose_z_to_y(wk13, wk2_r2c, sp)
-            call c2c_1m_y(wk2_r2c, -1, plan(0, 2))
+            call c2c_1m_y(wk2_r2c, plan(0, 2))
          else  ! out_c==wk2_r2c if 1D decomposition
             call transpose_z_to_y(wk13, out_c, sp)
-            call c2c_1m_y(out_c, -1, plan(0, 2))
+            call c2c_1m_y(out_c, plan(0, 2))
          end if
 
          ! ===== Swap Y --> X; 1D FFTs in X =====
          if (dims(1) > 1) then
             call transpose_y_to_x(wk2_r2c, out_c, sp)
          end if
-         call c2c_1m_x(out_c, -1, plan(0, 1))
+         call c2c_1m_x(out_c, plan(0, 1))
 
       end if
 
@@ -657,11 +642,11 @@ module decomp_2d_fft
 
          ! ===== 1D FFTs in Z =====
 #ifdef OVERWRITE
-         call c2c_1m_z(in_c, 1, plan(2, 3))
+         call c2c_1m_z(in_c, plan(2, 3))
 #else
          allocate (wk1(sp%zsz(1), sp%zsz(2), sp%zsz(3)))
          wk1 = in_c
-         call c2c_1m_z(wk1, 1, plan(2, 3))
+         call c2c_1m_z(wk1, plan(2, 3))
 #endif
 
          ! ===== Swap Z --> Y; 1D FFTs in Y =====
@@ -670,7 +655,7 @@ module decomp_2d_fft
 #else
          call transpose_z_to_y(wk1, wk2_r2c, sp)
 #endif
-         call c2c_1m_y(wk2_r2c, 1, plan(2, 2))
+         call c2c_1m_y(wk2_r2c, plan(2, 2))
 
          ! ===== Swap Y --> X; 1D FFTs in X =====
          if (dims(1) > 1) then
@@ -684,11 +669,11 @@ module decomp_2d_fft
 
          ! ===== 1D FFTs in X =====
 #ifdef OVERWRITE
-         call c2c_1m_x(in_c, 1, plan(2, 1))
+         call c2c_1m_x(in_c, plan(2, 1))
 #else
          allocate (wk1(sp%xsz(1), sp%xsz(2), sp%xsz(3)))
          wk1 = in_c
-         call c2c_1m_x(wk1, 1, plan(2, 1))
+         call c2c_1m_x(wk1, plan(2, 1))
 #endif
 
          ! ===== Swap X --> Y; 1D FFTs in Y =====
@@ -698,12 +683,12 @@ module decomp_2d_fft
 #else
             call transpose_x_to_y(wk1, wk2_r2c, sp)
 #endif
-            call c2c_1m_y(wk2_r2c, 1, plan(2, 2))
+            call c2c_1m_y(wk2_r2c, plan(2, 2))
          else  ! in_c==wk2_r2c if 1D decomposition
 #ifdef OVERWRITE
-            call c2c_1m_y(in_c, 1, plan(2, 2))
+            call c2c_1m_y(in_c, plan(2, 2))
 #else
-            call c2c_1m_y(wk1, 1, plan(2, 2))
+            call c2c_1m_y(wk1, plan(2, 2))
 #endif
          end if
 

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -61,7 +61,7 @@ module decomp_2d_fft
    type(C_PTR) :: wk2_c2c_p, wk13_p
 
    public :: decomp_2d_fft_init, decomp_2d_fft_3d, &
-             decomp_2d_fft_finalize, &
+             decomp_2d_fft_finalize, decomp_2d_fft_get_size, &
              decomp_2d_fft_get_ph, decomp_2d_fft_get_sp
 
    ! Declare generic interfaces to handle different inputs
@@ -239,6 +239,29 @@ contains
 
       return
    end subroutine decomp_2d_fft_finalize
+
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   ! Return the size, starting/ending index of the distributed array
+   !  whose global size is (nx/2+1)*ny*nz, for defining data structures
+   !  in r2c and c2r interfaces
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+   subroutine decomp_2d_fft_get_size(istart, iend, isize)
+
+      implicit none
+      integer, dimension(3), intent(OUT) :: istart, iend, isize
+
+      if (format == PHYSICAL_IN_X) then
+         istart = sp%zst
+         iend = sp%zen
+         isize = sp%zsz
+      else if (format == PHYSICAL_IN_Z) then
+         istart = sp%xst
+         iend = sp%xen
+         isize = sp%xsz
+      end if
+
+      return
+   end subroutine decomp_2d_fft_get_size
 
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
    ! Return a pointer to the decomp_info object ph

--- a/src/fft_log.f90
+++ b/src/fft_log.f90
@@ -59,7 +59,6 @@ contains
             write (io_unit, *) ''
          else if (D2D_FFT_BACKEND == D2D_FFT_BACKEND_FFTW3 .or. &
                   D2D_FFT_BACKEND == D2D_FFT_BACKEND_FFTW3_F03 .or. &
-                  D2D_FFT_BACKEND == D2D_FFT_BACKEND_CUFFT .or. &
                   D2D_FFT_BACKEND == D2D_FFT_BACKEND_MKL) then
             write (io_unit, *) 'OVERWRITE is supported but in-place transforms is limited to complex transforms'
             write (io_unit, *) ''

--- a/src/fft_log.f90
+++ b/src/fft_log.f90
@@ -53,13 +53,15 @@ contains
          call decomp_info_print(sp, io_unit, "sp")
          write (io_unit, *) ''
 #ifdef OVERWRITE
-         if (D2D_FFT_BACKEND == D2D_FFT_BACKEND_GENERIC) then
-            call decomp_2d_warning(D2D_FFT_BACKEND, "Selected FFT backend does not support overwrite")
+         if (D2D_FFT_BACKEND == D2D_FFT_BACKEND_GENERIC .or. &
+             D2D_FFT_BACKEND == D2D_FFT_BACKEND_CUFFT) then
+            write (io_unit, *) 'OVERWRITE is supported but transforms are not performed in-place'
+            write (io_unit, *) ''
          else if (D2D_FFT_BACKEND == D2D_FFT_BACKEND_FFTW3 .or. &
                   D2D_FFT_BACKEND == D2D_FFT_BACKEND_FFTW3_F03 .or. &
                   D2D_FFT_BACKEND == D2D_FFT_BACKEND_CUFFT .or. &
                   D2D_FFT_BACKEND == D2D_FFT_BACKEND_MKL) then
-            write (io_unit, *) 'OVERWRITE support limited to c2C and c2r transforms'
+            write (io_unit, *) 'OVERWRITE is supported but in-place transforms is limited to complex transforms'
             write (io_unit, *) ''
          end if
 #endif

--- a/src/transpose_x_to_y.f90
+++ b/src/transpose_x_to_y.f90
@@ -306,7 +306,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(in)
+        istat = cudaMemcpy2D( out(pos), i2-i1+1, in(i1,1,1), n1, i2-i1+1, n2*n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -360,7 +362,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(in)
+        istat = cudaMemcpy2D( out(pos), i2-i1+1, in(i1,1,1), n1, i2-i1+1, n2*n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -414,7 +418,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(1,i1,1), n1*n2, in(pos), n1*(i2-i1+1), n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -468,7 +474,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(1,i1,1), n1*n2, in(pos), n1*(i2-i1+1), n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data 
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3

--- a/src/transpose_y_to_x.f90
+++ b/src/transpose_y_to_x.f90
@@ -306,7 +306,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(in)
+        istat = cudaMemcpy2D( out(pos), n1*(i2-i1+1), in(1,i1,1), n1*n2, n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -360,7 +362,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(in)
+        istat = cudaMemcpy2D( out(pos), n1*(i2-i1+1), in(1,i1,1), n1*n2, n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -414,7 +418,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(i1,1,1), n1, in(pos), i2-i1+1, i2-i1+1, n2*n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -468,7 +474,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(i1,1,1), n1, in(pos), i2-i1+1, i2-i1+1, n2*n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3

--- a/src/transpose_y_to_z.f90
+++ b/src/transpose_y_to_z.f90
@@ -152,7 +152,11 @@
      ! so no merge operation needed
 
 #if defined(_GPU)
-     istat = cudaMemcpy(dst, work2_r_d, d1*d2*d3, cudaMemcpyDeviceToDevice)
+     !If one of the array in cuda call is not device we need to add acc host_data
+     !$acc host_data use_device(dst)
+     istat = cudaMemcpy( dst, work2_r_d, d1*d2*d3, cudaMemcpyDeviceToDevice )
+     !$acc end host_data
+     if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
 
 #endif
@@ -284,7 +288,10 @@
      ! so no merge operation needed
 
 #if defined(_GPU)
-     istat = cudaMemcpy(dst, work2_c_d, d1*d2*d3, cudaMemcpyDeviceToDevice)
+    !$acc host_data use_device(dst)
+    istat = cudaMemcpy( dst, work2_c_d, d1*d2*d3, cudaMemcpyDeviceToDevice )
+    !$acc end host_data
+    if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
 
 #endif
@@ -334,7 +341,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(in)
+        istat = cudaMemcpy2D( out(pos), n1*(i2-i1+1), in(1,i1,1), n1*n2, n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -388,8 +397,10 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
-        if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
+       !$acc host_data use_device(in)
+       istat = cudaMemcpy2D( out(pos), n1*(i2-i1+1), in(1,i1,1), n1*n2, n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+       !$acc end host_data
+       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
            do j = i1, i2

--- a/src/transpose_z_to_y.f90
+++ b/src/transpose_z_to_y.f90
@@ -73,7 +73,10 @@
      ! so no split operation needed
 
 #if defined(_GPU)
-     istat = cudaMemcpy(work1_r_d, src, s1*s2*s3)
+     !$acc host_data use_device(src)
+     istat = cudaMemcpy( work1_r_d, src, s1*s2*s3, cudaMemcpyDeviceToDevice )
+     !$acc end host_data
+     if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
 
 #endif
@@ -220,7 +223,10 @@
      ! so no split operation needed
 
 #if defined(_GPU)
-     istat = cudaMemcpy(work1_c_d, src, s1*s2*s3)
+     !$acc host_data use_device(src)
+     istat = cudaMemcpy( work1_c_d, src, s1*s2*s3, cudaMemcpyDeviceToDevice )
+     !$acc end host_data
+     if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
 
 #endif
@@ -424,7 +430,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(1,i1,1), n1*n2, in(pos), n1*(i2-i1+1), n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3
@@ -479,7 +487,9 @@
 #endif
 
 #if defined(_GPU)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        !$acc host_data use_device(out)
+        istat = cudaMemcpy2D( out(1,i1,1), n1*n2, in(pos), n1*(i2-i1+1), n1*(i2-i1+1), n3, cudaMemcpyDeviceToDevice )
+        !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
         do k = 1, n3


### PR DESCRIPTION
I have updated also the tests for 2decomp to adapt for the non memory managed case for GPU. The only missing is the halo since it requires some changes in the routines. 
I’ll also open a feature request to adapt the IO part of 2decomp. In the example of io for single plane only the write for aligned planes works  (i.e. X write for u1). The write plane has some transposes and for the manual memory management we need. This will give at least consistency that when doing IO we move the data to the host and we write from there. 
I would like to do the pull request to allow Wei and I to put properly the sin/cos transform. 
