### PR TITLE
Run fprettify --enable-replacements --c-relations -w 3 src/*f90 examples/*/*f90

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,10 @@ add_subdirectory(src)
 # Add tests
 add_subdirectory(examples)
 
+# Add a prettify target
+add_custom_target(format sh ${CMAKE_SOURCE_DIR}/scripts/format.sh
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+
 # # Create an example dir with all input.i3d example files
 # option(BUILD_TESTING "Build with tests" ON)
 # set(test_dir "${PROJECT_BINARY_DIR}/Test")

--- a/README.md
+++ b/README.md
@@ -224,6 +224,11 @@ This variable is automatically added in GPU builds.
 
 This variable is valid only for GPU builds. The NVIDIA Collective Communication Library (NCCL) implements multi-GPU and multi-node communication primitives optimized for NVIDIA GPUs and Networking.
 
+### Code formatting
+
+The code is formatted using the `fprettify` program (available via `pip`), to ensure consistency of use there is a script file `scripts/format.sh` which will run `fprettify` across the 2decomp&fft source, you can also use the `format` build target to run the script.
+It is recommended that you should format the code before making a pull request.
+
 ## Optional dependencies
 
 ### FFTW

--- a/examples/fft_physical_x/fft_grid_x.f90
+++ b/examples/fft_physical_x/fft_grid_x.f90
@@ -36,10 +36,10 @@ program fft_physical_x
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -98,8 +98,8 @@ program fft_physical_x
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             di = dr
             in(i, j, k) = cmplx(dr, di, mytype)
          end do
@@ -123,7 +123,7 @@ program fft_physical_x
 
       ! normalisation - note 2DECOMP&FFT doesn't normalise
       !$acc kernels
-      in = in/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+      in = in / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
       !$acc end kernels
 
    end do
@@ -133,10 +133,10 @@ program fft_physical_x
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
 
    ! checking accuracy
    error = 0._mytype
@@ -144,31 +144,31 @@ program fft_physical_x
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             di = dr
             dr = dr - real(in(i, j, k), mytype)
             di = di - aimag(in(i, j, k))
-            error = error + sqrt(dr*dr + di*di)
+            error = error + sqrt(dr * dr + di * di)
          end do
       end do
    end do
    !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
-   err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+   err_all = err_all / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
 
    if (nrank == 0) then
       write (*, *) '===== c2c interface ====='
       write (*, *) 'error / mesh point: ', err_all
       write (*, *) 'time (sec): ', t1, t3
-      n1 = real(nx, mytype)*real(ny, mytype)*real(nz, mytype)
-      n1 = n1**(1._mytype/3._mytype)
+      n1 = real(nx, mytype) * real(ny, mytype) * real(nz, mytype)
+      n1 = n1**(1._mytype / 3._mytype)
       ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
-      flops = 5._mytype*n1*log(n1)/log(2.0_mytype)
+      flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
       ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
-      flops = flops*3._mytype*n1**2
-      flops = 2._mytype*flops/((t1 + t3)/real(NTEST, mytype))
-      write (*, *) 'GFLOPS : ', flops/1000._mytype**3
+      flops = flops * 3._mytype * n1**2
+      flops = 2._mytype * flops / ((t1 + t3) / real(NTEST, mytype))
+      write (*, *) 'GFLOPS : ', flops / 1000._mytype**3
    end if
    !$acc end data
 

--- a/examples/fft_physical_x/fft_r2c_x.f90
+++ b/examples/fft_physical_x/fft_r2c_x.f90
@@ -37,10 +37,10 @@ program fft_r2c_x
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -99,8 +99,8 @@ program fft_r2c_x
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            in_r(i, j, k) = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                            /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            in_r(i, j, k) = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                            / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
          end do
       end do
    end do
@@ -122,7 +122,7 @@ program fft_r2c_x
 
       ! normalisation - note 2DECOMP&FFT doesn't normalise
       !$acc kernels
-      in_r = in_r/(real(nx, mytype)*real(ny, mytype)*real(nz, mytype))
+      in_r = in_r / (real(nx, mytype) * real(ny, mytype) * real(nz, mytype))
       !$acc end kernels
 
    end do
@@ -132,10 +132,10 @@ program fft_r2c_x
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
 
    ! checking accuracy
    error = 0._mytype
@@ -143,15 +143,15 @@ program fft_r2c_x
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             error = error + abs(in_r(i, j, k) - dr)
          end do
       end do
    end do
    !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
-   err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+   err_all = err_all / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
 
    if (nrank == 0) then
       write (*, *) '===== r2c/c2r interface ====='

--- a/examples/fft_physical_z/fft_c2c_z.f90
+++ b/examples/fft_physical_z/fft_c2c_z.f90
@@ -36,10 +36,10 @@ program fft_c2c_z
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -98,8 +98,8 @@ program fft_c2c_z
    do k = zst3, zen3
       do j = zst2, zen2
          do i = zst1, zen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             di = dr
             in(i, j, k) = cmplx(dr, di, mytype)
          end do
@@ -123,7 +123,7 @@ program fft_c2c_z
 
       ! normalisation - note 2DECOMP&FFT doesn't normalise
       !$acc kernels
-      in = in/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+      in = in / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
       !$acc end kernels
 
    end do
@@ -133,10 +133,10 @@ program fft_c2c_z
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
 
    ! checking accuracy
    error = 0._mytype
@@ -144,31 +144,31 @@ program fft_c2c_z
    do k = zst3, zen3
       do j = zst2, zen2
          do i = zst1, zen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             di = dr
             dr = dr - real(in(i, j, k), mytype)
             di = di - aimag(in(i, j, k))
-            error = error + sqrt(dr*dr + di*di)
+            error = error + sqrt(dr * dr + di * di)
          end do
       end do
    end do
    !$acc end loop
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
-   err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+   err_all = err_all / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
 
    if (nrank == 0) then
       write (*, *) '===== c2c interface ====='
       write (*, *) 'error / mesh point: ', err_all
       write (*, *) 'time (sec): ', t1, t3
-      n1 = real(nx, mytype)*real(ny, mytype)*real(nz, mytype)
-      n1 = n1**(1._mytype/3._mytype)
+      n1 = real(nx, mytype) * real(ny, mytype) * real(nz, mytype)
+      n1 = n1**(1._mytype / 3._mytype)
       ! 5n*log(n) flops per 1D FFT of size n using Cooley-Tukey algorithm
-      flops = 5._mytype*n1*log(n1)/log(2.0_mytype)
+      flops = 5._mytype * n1 * log(n1) / log(2.0_mytype)
       ! 3 sets of 1D FFTs for 3 directions, each having n^2 1D FFTs
-      flops = flops*3._mytype*n1**2
-      flops = 2._mytype*flops/((t1 + t3)/real(NTEST, mytype))
-      write (*, *) 'GFLOPS : ', flops/1000._mytype**3
+      flops = flops * 3._mytype * n1**2
+      flops = 2._mytype * flops / ((t1 + t3) / real(NTEST, mytype))
+      write (*, *) 'GFLOPS : ', flops / 1000._mytype**3
    end if
    !$acc end data
 

--- a/examples/fft_physical_z/fft_r2c_z.f90
+++ b/examples/fft_physical_z/fft_r2c_z.f90
@@ -37,10 +37,10 @@ program fft_r2c_z
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -100,8 +100,8 @@ program fft_r2c_z
    do k = zst3, zen3
       do j = zst2, zen2
          do i = zst1, zen1
-            in_r(i, j, k) = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                            /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            in_r(i, j, k) = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                            / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
          end do
       end do
    end do
@@ -122,7 +122,7 @@ program fft_r2c_z
       t4 = t4 + MPI_WTIME() - t3
 
       !$acc kernels
-      in_r = in_r/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+      in_r = in_r / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
       !$acc end kernels
 
    end do
@@ -132,10 +132,10 @@ program fft_r2c_z
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
 
    ! checking accuracy
    error = 0._mytype
@@ -143,8 +143,8 @@ program fft_r2c_z
    do k = zst3, zen3
       do j = zst2, zen2
          do i = zst1, zen1
-            dr = real(i, mytype)/real(nx, mytype)*real(j, mytype) &
-                 /real(ny, mytype)*real(k, mytype)/real(nz, mytype)
+            dr = real(i, mytype) / real(nx, mytype) * real(j, mytype) &
+                 / real(ny, mytype) * real(k, mytype) / real(nz, mytype)
             error = error + abs(in_r(i, j, k) - dr)
             !write(*,10) nrank,k,j,i,dr,in_r(i,j,k)
          end do
@@ -154,7 +154,7 @@ program fft_r2c_z
 !10 format('in_r final ', I2,1x,I2,1x,I2,1x,I2,1x,F12.6,1x,F12.6)
 
    call MPI_ALLREDUCE(error, err_all, 1, real_type, MPI_SUM, MPI_COMM_WORLD, ierror)
-   err_all = err_all/real(nx, mytype)/real(ny, mytype)/real(nz, mytype)
+   err_all = err_all / real(nx, mytype) / real(ny, mytype) / real(nz, mytype)
 
    if (nrank == 0) then
       write (*, *) '===== r2c/c2r interface ====='

--- a/examples/halo_test/halo_test.f90
+++ b/examples/halo_test/halo_test.f90
@@ -47,10 +47,10 @@ program halo_test
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -517,7 +517,7 @@ contains
       !$acc end kernels
       divmag = mag(tmp)
 
-      if (err < epsilon(divmag)*divmag) then
+      if (err < epsilon(divmag) * divmag) then
          passing = .true.
       else
          passing = .false.
@@ -530,7 +530,7 @@ contains
 #ifdef DEBUG
          write (*, *) (divh(i, i, i), i=2, 13)
 #endif
-         write (*, *) 'Error: ', err, '; Relative: ', err/divmag
+         write (*, *) 'Error: ', err, '; Relative: ', err / divmag
          write (*, *) 'Pass: ', passing
       end if
       deallocate (tmp)
@@ -567,7 +567,7 @@ contains
                               "halo_test::mag::MPI_Allreduce")
       end if
 
-      mag = sqrt(gmag/(nx - 2)/(ny - 2)/(nz - 2))
+      mag = sqrt(gmag / (nx - 2) / (ny - 2) / (nz - 2))
 
    end function mag
    !=====================================================================

--- a/examples/init_test/init_test.f90
+++ b/examples/init_test/init_test.f90
@@ -30,10 +30,10 @@ program init_test
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -71,7 +71,7 @@ program init_test
          print *, "will be used"
       end if
    end if
-   nexpect = nx*ny*nz
+   nexpect = nx * ny * nz
    call run(p_row, p_col)
 
    call MPI_Finalize(ierror)

--- a/examples/io_test/io_bench.f90
+++ b/examples/io_test/io_bench.f90
@@ -29,10 +29,10 @@ program io_bench
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()

--- a/examples/io_test/io_plane_test.f90
+++ b/examples/io_test/io_plane_test.f90
@@ -40,10 +40,10 @@ program io_plane_test
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -124,17 +124,17 @@ program io_plane_test
    !$acc update self(u3)
    !$acc end data
    ! X-pencil data
-   call decomp_2d_write_plane(1, u1, 1, nx/2, '.', 'x_pencil-x_plane.dat', 'test')
-   call decomp_2d_write_plane(1, u1, 2, ny/2, '.', 'x_pencil-y_plane.dat', 'test')
-   call decomp_2d_write_plane(1, u1, 3, nz/2, '.', 'x_pencil-z_plane.dat', 'test')
+   call decomp_2d_write_plane(1, u1, 1, nx / 2, '.', 'x_pencil-x_plane.dat', 'test')
+   call decomp_2d_write_plane(1, u1, 2, ny / 2, '.', 'x_pencil-y_plane.dat', 'test')
+   call decomp_2d_write_plane(1, u1, 3, nz / 2, '.', 'x_pencil-z_plane.dat', 'test')
    ! Y-pencil data
-   call decomp_2d_write_plane(2, u2, 2, ny/2, '.', 'y_pencil-y_plane.dat', 'test')
-   call decomp_2d_write_plane(2, u2, 1, nx/2, '.', 'y_pencil-x_plane.dat', 'test')
-   call decomp_2d_write_plane(2, u2, 3, nz/2, '.', 'y_pencil-z_plane.dat', 'test')
+   call decomp_2d_write_plane(2, u2, 2, ny / 2, '.', 'y_pencil-y_plane.dat', 'test')
+   call decomp_2d_write_plane(2, u2, 1, nx / 2, '.', 'y_pencil-x_plane.dat', 'test')
+   call decomp_2d_write_plane(2, u2, 3, nz / 2, '.', 'y_pencil-z_plane.dat', 'test')
    ! Z-pencil data
-   call decomp_2d_write_plane(3, u3, 1, nx/2, '.', 'z_pencil-x_plane.dat', 'test')
-   call decomp_2d_write_plane(3, u3, 2, ny/2, '.', 'z_pencil-y_plane.dat', 'test')
-   call decomp_2d_write_plane(3, u3, 3, nz/2, '.', 'z_pencil-z_plane.dat', 'test')
+   call decomp_2d_write_plane(3, u3, 1, nx / 2, '.', 'z_pencil-x_plane.dat', 'test')
+   call decomp_2d_write_plane(3, u3, 2, ny / 2, '.', 'z_pencil-y_plane.dat', 'test')
+   call decomp_2d_write_plane(3, u3, 3, nz / 2, '.', 'z_pencil-z_plane.dat', 'test')
    ! Attemp to read the files
    if (nrank == 0) then
       inquire (iolength=iol) data1(1, 1, 1)

--- a/examples/io_test/io_read.f90
+++ b/examples/io_test/io_read.f90
@@ -38,10 +38,10 @@ program io_read
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -89,7 +89,7 @@ program io_read
       do j = 1, ny
          do i = 1, nx
 #ifdef COMPLEX_TEST
-            data1(i, j, k) = cmplx(real(m, mytype), real(nx*ny*nz - m, mytype))
+            data1(i, j, k) = cmplx(real(m, mytype), real(nx * ny * nz - m, mytype))
 #else
             data1(i, j, k) = real(m, mytype)
 #endif

--- a/examples/io_test/io_test.f90
+++ b/examples/io_test/io_test.f90
@@ -42,10 +42,10 @@ program io_test
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -93,7 +93,7 @@ program io_test
       do j = 1, ny
          do i = 1, nx
 #ifdef COMPLEX_TEST
-            data1(i, j, k) = cmplx(real(m, mytype), real(nx*ny*nz - m, mytype))
+            data1(i, j, k) = cmplx(real(m, mytype), real(nx * ny * nz - m, mytype))
 #else
             data1(i, j, k) = real(m, mytype)
 #endif

--- a/examples/io_test/io_var_test.f90
+++ b/examples/io_test/io_var_test.f90
@@ -57,10 +57,10 @@ program io_var_test
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -102,12 +102,12 @@ program io_var_test
    call decomp_2d_init(nx, ny, nz, p_row, p_col)
 
    ! also create a data set over a large domain
-   call decomp_info_init(nx*2, ny*2, nz*2, large)
+   call decomp_info_init(nx * 2, ny * 2, nz * 2, large)
 
    ! initialise global data
    allocate (data1(nx, ny, nz))
    allocate (cdata1(nx, ny, nz))
-   allocate (data1_large(nx*2, ny*2, nz*2))
+   allocate (data1_large(nx * 2, ny * 2, nz * 2))
    m = 1
    do k = 1, nz
       do j = 1, ny
@@ -120,9 +120,9 @@ program io_var_test
    end do
 
    m = 1
-   do k = 1, nz*2
-      do j = 1, ny*2
-         do i = 1, nx*2
+   do k = 1, nz * 2
+      do j = 1, ny * 2
+         do i = 1, nx * 2
             data1_large(i, j, k) = real(m, mytype)
             m = m + 1
          end do

--- a/examples/test2d/test2d.f90
+++ b/examples/test2d/test2d.f90
@@ -38,10 +38,10 @@ program test2d
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -118,7 +118,7 @@ program test2d
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             u1(i, j, k) = m
          end do
       end do
@@ -160,7 +160,7 @@ program test2d
    do k = yst3, yen3
       do j = yst2, yen2
          do i = yst1, yen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             if (abs(u2(i, j, k) - m) > 0) error_flag = .true.
          end do
       end do
@@ -190,7 +190,7 @@ program test2d
    do k = zst3, zen3
       do j = zst2, zen2
          do i = zst1, zen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             if (abs(u3(i, j, k) - m) > 0) error_flag = .true.
          end do
       end do
@@ -209,7 +209,7 @@ program test2d
    do k = yst3, yen3
       do j = yst2, yen2
          do i = yst1, yen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             if (abs(u2(i, j, k) - m) > 0) error_flag = .true.
          end do
       end do
@@ -228,7 +228,7 @@ program test2d
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             if (abs(u1(i, j, k) - m) > 0) error_flag = .true.
          end do
       end do

--- a/examples/test2d/timing2d_complex.f90
+++ b/examples/test2d/timing2d_complex.f90
@@ -42,10 +42,10 @@ program timing2d_complex
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -122,7 +122,7 @@ program timing2d_complex
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             u1(i, j, k) = cmplx(m, real(m - 1, mytype), kind=mytype)
          end do
       end do
@@ -171,7 +171,7 @@ program timing2d_complex
       do k = yst3, yen3
          do j = yst2, yen2
             do i = yst1, yen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                cm = cmplx(m, real(m - 1, mytype), kind=mytype)
                if (abs(u2(i, j, k) - cm) > 0) error_flag = .true.
             end do
@@ -204,7 +204,7 @@ program timing2d_complex
       do k = zst3, zen3
          do j = zst2, zen2
             do i = zst1, zen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                cm = cmplx(m, real(m - 1, mytype), kind=mytype)
                if (abs(u3(i, j, k) - cm) > 0) error_flag = .true.
             end do
@@ -226,7 +226,7 @@ program timing2d_complex
       do k = yst3, yen3
          do j = yst2, yen2
             do i = yst1, yen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                cm = cmplx(m, real(m - 1, mytype), kind=mytype)
                if (abs(u2(i, j, k) - cm) > 0) error_flag = .true.
             end do
@@ -248,7 +248,7 @@ program timing2d_complex
       do k = xst3, xen3
          do j = xst2, xen2
             do i = xst1, xen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                cm = cmplx(m, real(m - 1, mytype), kind=mytype)
                if (abs(u1(i, j, k) - cm) > 0) error_flag = .true.
             end do
@@ -262,16 +262,16 @@ program timing2d_complex
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
    call MPI_ALLREDUCE(t6, t5, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t5 = t5/dble(nproc)
+   t5 = t5 / dble(nproc)
    call MPI_ALLREDUCE(t8, t7, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t7 = t7/dble(nproc)
+   t7 = t7 / dble(nproc)
    t8 = t1 + t3 + t5 + t7
    if (nrank == 0) then
       write (*, *) 'Time X->Y ', t1

--- a/examples/test2d/timing2d_real.f90
+++ b/examples/test2d/timing2d_real.f90
@@ -41,10 +41,10 @@ program timing2d_real
    ! To resize the domain we need to know global number of ranks
    ! This operation is also done as part of decomp_2d_init
    call MPI_COMM_SIZE(MPI_COMM_WORLD, nranks_tot, ierror)
-   resize_domain = int(nranks_tot/4) + 1
-   nx = nx_base*resize_domain
-   ny = ny_base*resize_domain
-   nz = nz_base*resize_domain
+   resize_domain = int(nranks_tot / 4) + 1
+   nx = nx_base * resize_domain
+   ny = ny_base * resize_domain
+   nz = nz_base * resize_domain
    ! Now we can check if user put some inputs
    ! Handle input file like a boss -- GD
    nargin = command_argument_count()
@@ -121,7 +121,7 @@ program timing2d_real
    do k = xst3, xen3
       do j = xst2, xen2
          do i = xst1, xen1
-            m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+            m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
             u1(i, j, k) = m
          end do
       end do
@@ -170,7 +170,7 @@ program timing2d_real
       do k = yst3, yen3
          do j = yst2, yen2
             do i = yst1, yen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                if (abs(u2(i, j, k) - m) > 0) error_flag = .true.
             end do
          end do
@@ -202,7 +202,7 @@ program timing2d_real
       do k = zst3, zen3
          do j = zst2, zen2
             do i = zst1, zen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                if (abs(u3(i, j, k) - m) > 0) error_flag = .true.
             end do
          end do
@@ -223,7 +223,7 @@ program timing2d_real
       do k = yst3, yen3
          do j = yst2, yen2
             do i = yst1, yen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                if (abs(u2(i, j, k) - m) > 0) error_flag = .true.
             end do
          end do
@@ -244,7 +244,7 @@ program timing2d_real
       do k = xst3, xen3
          do j = xst2, xen2
             do i = xst1, xen1
-               m = real(i + (j - 1)*nx + (k - 1)*nx*ny, mytype)
+               m = real(i + (j - 1) * nx + (k - 1) * nx * ny, mytype)
                if (abs(u1(i, j, k) - m) > 0) error_flag = .true.
             end do
          end do
@@ -257,16 +257,16 @@ program timing2d_real
 
    call MPI_ALLREDUCE(t2, t1, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t1 = t1/dble(nproc)
+   t1 = t1 / dble(nproc)
    call MPI_ALLREDUCE(t4, t3, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t3 = t3/dble(nproc)
+   t3 = t3 / dble(nproc)
    call MPI_ALLREDUCE(t6, t5, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t5 = t5/dble(nproc)
+   t5 = t5 / dble(nproc)
    call MPI_ALLREDUCE(t8, t7, 1, MPI_DOUBLE_PRECISION, MPI_SUM, &
                       MPI_COMM_WORLD, ierror)
-   t7 = t7/dble(nproc)
+   t7 = t7 / dble(nproc)
    t8 = t1 + t3 + t5 + t7
    if (nrank == 0) then
       write (*, *) 'Time X->Y ', t1

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -4,8 +4,12 @@
 #
 # Runs the prettifier over 2decomp sources.
 
+# Find 2decomp root
+SCRDIR=$( dirname -- "$0"; )
+D2DDIR=${SCRDIR}/../
+
 # fprettify options
 # --enable-replacements : Replaces relational operators, e.g. .lt. -> <
 # --c-relations : Use C-style relational operators, e.g. <=
 # -w 3 : Whitespace preset - operators, print/read, *, /, +, -
-fprettify --enable-replacements --c-relations -w 3 src/*f90 examples/*/*f90
+fprettify --enable-replacements --c-relations -w 3 ${D2DDIR}/src/*f90 ${D2DDIR}/examples/*/*f90

--- a/scripts/format.sh
+++ b/scripts/format.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+#
+# format.sh
+#
+# Runs the prettifier over 2decomp sources.
+
+# fprettify options
+# --enable-replacements : Replaces relational operators, e.g. .lt. -> <
+# --c-relations : Use C-style relational operators, e.g. <=
+# -w 3 : Whitespace preset - operators, print/read, *, /, +, -
+fprettify --enable-replacements --c-relations -w 3 src/*f90 examples/*/*f90

--- a/src/decomp_2d.f90
+++ b/src/decomp_2d.f90
@@ -403,13 +403,13 @@ contains
       ! allocate memory for the MPI_ALLTOALL(V) buffers
       ! define the buffers globally for performance reason
 
-      buf_size = max(decomp%xsz(1)*decomp%xsz(2)*decomp%xsz(3), &
-                     max(decomp%ysz(1)*decomp%ysz(2)*decomp%ysz(3), &
-                         decomp%zsz(1)*decomp%zsz(2)*decomp%zsz(3)))
+      buf_size = max(decomp%xsz(1) * decomp%xsz(2) * decomp%xsz(3), &
+                     max(decomp%ysz(1) * decomp%ysz(2) * decomp%ysz(3), &
+                         decomp%zsz(1) * decomp%zsz(2) * decomp%zsz(3)))
 #ifdef EVEN
       ! padded alltoall optimisation may need larger buffer space
       buf_size = max(buf_size, &
-                     max(decomp%x1count*dims(1), decomp%y2count*dims(2)))
+                     max(decomp%x1count * dims(1), decomp%y2count * dims(2)))
 #endif
 
       ! check if additional memory is required
@@ -502,39 +502,39 @@ contains
 
       do i = 1, 3
          if (from1) then
-            xstS(i) = (xstart(i) + skip(i) - 1)/skip(i)
+            xstS(i) = (xstart(i) + skip(i) - 1) / skip(i)
             if (mod(xstart(i) + skip(i) - 1, skip(i)) /= 0) xstS(i) = xstS(i) + 1
-            xenS(i) = (xend(i) + skip(i) - 1)/skip(i)
+            xenS(i) = (xend(i) + skip(i) - 1) / skip(i)
          else
-            xstS(i) = xstart(i)/skip(i)
+            xstS(i) = xstart(i) / skip(i)
             if (mod(xstart(i), skip(i)) /= 0) xstS(i) = xstS(i) + 1
-            xenS(i) = xend(i)/skip(i)
+            xenS(i) = xend(i) / skip(i)
          end if
          xszS(i) = xenS(i) - xstS(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            ystS(i) = (ystart(i) + skip(i) - 1)/skip(i)
+            ystS(i) = (ystart(i) + skip(i) - 1) / skip(i)
             if (mod(ystart(i) + skip(i) - 1, skip(i)) /= 0) ystS(i) = ystS(i) + 1
-            yenS(i) = (yend(i) + skip(i) - 1)/skip(i)
+            yenS(i) = (yend(i) + skip(i) - 1) / skip(i)
          else
-            ystS(i) = ystart(i)/skip(i)
+            ystS(i) = ystart(i) / skip(i)
             if (mod(ystart(i), skip(i)) /= 0) ystS(i) = ystS(i) + 1
-            yenS(i) = yend(i)/skip(i)
+            yenS(i) = yend(i) / skip(i)
          end if
          yszS(i) = yenS(i) - ystS(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            zstS(i) = (zstart(i) + skip(i) - 1)/skip(i)
+            zstS(i) = (zstart(i) + skip(i) - 1) / skip(i)
             if (mod(zstart(i) + skip(i) - 1, skip(i)) /= 0) zstS(i) = zstS(i) + 1
-            zenS(i) = (zend(i) + skip(i) - 1)/skip(i)
+            zenS(i) = (zend(i) + skip(i) - 1) / skip(i)
          else
-            zstS(i) = zstart(i)/skip(i)
+            zstS(i) = zstart(i) / skip(i)
             if (mod(zstart(i), skip(i)) /= 0) zstS(i) = zstS(i) + 1
-            zenS(i) = zend(i)/skip(i)
+            zenS(i) = zend(i) / skip(i)
          end if
          zszS(i) = zenS(i) - zstS(i) + 1
       end do
@@ -567,39 +567,39 @@ contains
 
       do i = 1, 3
          if (from1) then
-            xstV(i) = (xstart(i) + skip(i) - 1)/skip(i)
+            xstV(i) = (xstart(i) + skip(i) - 1) / skip(i)
             if (mod(xstart(i) + skip(i) - 1, skip(i)) /= 0) xstV(i) = xstV(i) + 1
-            xenV(i) = (xend(i) + skip(i) - 1)/skip(i)
+            xenV(i) = (xend(i) + skip(i) - 1) / skip(i)
          else
-            xstV(i) = xstart(i)/skip(i)
+            xstV(i) = xstart(i) / skip(i)
             if (mod(xstart(i), skip(i)) /= 0) xstV(i) = xstV(i) + 1
-            xenV(i) = xend(i)/skip(i)
+            xenV(i) = xend(i) / skip(i)
          end if
          xszV(i) = xenV(i) - xstV(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            ystV(i) = (ystart(i) + skip(i) - 1)/skip(i)
+            ystV(i) = (ystart(i) + skip(i) - 1) / skip(i)
             if (mod(ystart(i) + skip(i) - 1, skip(i)) /= 0) ystV(i) = ystV(i) + 1
-            yenV(i) = (yend(i) + skip(i) - 1)/skip(i)
+            yenV(i) = (yend(i) + skip(i) - 1) / skip(i)
          else
-            ystV(i) = ystart(i)/skip(i)
+            ystV(i) = ystart(i) / skip(i)
             if (mod(ystart(i), skip(i)) /= 0) ystV(i) = ystV(i) + 1
-            yenV(i) = yend(i)/skip(i)
+            yenV(i) = yend(i) / skip(i)
          end if
          yszV(i) = yenV(i) - ystV(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            zstV(i) = (zstart(i) + skip(i) - 1)/skip(i)
+            zstV(i) = (zstart(i) + skip(i) - 1) / skip(i)
             if (mod(zstart(i) + skip(i) - 1, skip(i)) /= 0) zstV(i) = zstV(i) + 1
-            zenV(i) = (zend(i) + skip(i) - 1)/skip(i)
+            zenV(i) = (zend(i) + skip(i) - 1) / skip(i)
          else
-            zstV(i) = zstart(i)/skip(i)
+            zstV(i) = zstart(i) / skip(i)
             if (mod(zstart(i), skip(i)) /= 0) zstV(i) = zstV(i) + 1
-            zenV(i) = zend(i)/skip(i)
+            zenV(i) = zend(i) / skip(i)
          end if
          zszV(i) = zenV(i) - zstV(i) + 1
       end do
@@ -632,39 +632,39 @@ contains
 
       do i = 1, 3
          if (from1) then
-            xstP(i) = (xstart(i) + skip(i) - 1)/skip(i)
+            xstP(i) = (xstart(i) + skip(i) - 1) / skip(i)
             if (mod(xstart(i) + skip(i) - 1, skip(i)) /= 0) xstP(i) = xstP(i) + 1
-            xenP(i) = (xend(i) + skip(i) - 1)/skip(i)
+            xenP(i) = (xend(i) + skip(i) - 1) / skip(i)
          else
-            xstP(i) = xstart(i)/skip(i)
+            xstP(i) = xstart(i) / skip(i)
             if (mod(xstart(i), skip(i)) /= 0) xstP(i) = xstP(i) + 1
-            xenP(i) = xend(i)/skip(i)
+            xenP(i) = xend(i) / skip(i)
          end if
          xszP(i) = xenP(i) - xstP(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            ystP(i) = (ystart(i) + skip(i) - 1)/skip(i)
+            ystP(i) = (ystart(i) + skip(i) - 1) / skip(i)
             if (mod(ystart(i) + skip(i) - 1, skip(i)) /= 0) ystP(i) = ystP(i) + 1
-            yenP(i) = (yend(i) + skip(i) - 1)/skip(i)
+            yenP(i) = (yend(i) + skip(i) - 1) / skip(i)
          else
-            ystP(i) = ystart(i)/skip(i)
+            ystP(i) = ystart(i) / skip(i)
             if (mod(ystart(i), skip(i)) /= 0) ystP(i) = ystP(i) + 1
-            yenP(i) = yend(i)/skip(i)
+            yenP(i) = yend(i) / skip(i)
          end if
          yszP(i) = yenP(i) - ystP(i) + 1
       end do
 
       do i = 1, 3
          if (from1) then
-            zstP(i) = (zstart(i) + skip(i) - 1)/skip(i)
+            zstP(i) = (zstart(i) + skip(i) - 1) / skip(i)
             if (mod(zstart(i) + skip(i) - 1, skip(i)) /= 0) zstP(i) = zstP(i) + 1
-            zenP(i) = (zend(i) + skip(i) - 1)/skip(i)
+            zenP(i) = (zend(i) + skip(i) - 1) / skip(i)
          else
-            zstP(i) = zstart(i)/skip(i)
+            zstP(i) = zstart(i) / skip(i)
             if (mod(zstart(i), skip(i)) /= 0) zstP(i) = zstP(i) + 1
-            zenP(i) = zend(i)/skip(i)
+            zenP(i) = zend(i) / skip(i)
          end if
          zszP(i) = zenP(i) - zstP(i) + 1
       end do
@@ -692,7 +692,7 @@ contains
             do k = xstS(3), xenS(3)
                do j = xstS(2), xenS(2)
                   do i = xstS(1), xenS(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipS + 1, (j - 1)*jskipS + 1, (k - 1)*kskipS + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipS + 1, (j - 1) * jskipS + 1, (k - 1) * kskipS + 1)
                   end do
                end do
             end do
@@ -700,7 +700,7 @@ contains
             do k = xstS(3), xenS(3)
                do j = xstS(2), xenS(2)
                   do i = xstS(1), xenS(1)
-                     wk(i, j, k) = wk2(i*iskipS, j*jskipS, k*kskipS)
+                     wk(i, j, k) = wk2(i * iskipS, j * jskipS, k * kskipS)
                   end do
                end do
             end do
@@ -714,7 +714,7 @@ contains
             do k = ystS(3), yenS(3)
                do j = ystS(2), yenS(2)
                   do i = ystS(1), yenS(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipS + 1, (j - 1)*jskipS + 1, (k - 1)*kskipS + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipS + 1, (j - 1) * jskipS + 1, (k - 1) * kskipS + 1)
                   end do
                end do
             end do
@@ -722,7 +722,7 @@ contains
             do k = ystS(3), yenS(3)
                do j = ystS(2), yenS(2)
                   do i = ystS(1), yenS(1)
-                     wk(i, j, k) = wk2(i*iskipS, j*jskipS, k*kskipS)
+                     wk(i, j, k) = wk2(i * iskipS, j * jskipS, k * kskipS)
                   end do
                end do
             end do
@@ -736,7 +736,7 @@ contains
             do k = zstS(3), zenS(3)
                do j = zstS(2), zenS(2)
                   do i = zstS(1), zenS(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipS + 1, (j - 1)*jskipS + 1, (k - 1)*kskipS + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipS + 1, (j - 1) * jskipS + 1, (k - 1) * kskipS + 1)
                   end do
                end do
             end do
@@ -744,7 +744,7 @@ contains
             do k = zstS(3), zenS(3)
                do j = zstS(2), zenS(2)
                   do i = zstS(1), zenS(1)
-                     wk(i, j, k) = wk2(i*iskipS, j*jskipS, k*kskipS)
+                     wk(i, j, k) = wk2(i * iskipS, j * jskipS, k * kskipS)
                   end do
                end do
             end do
@@ -777,7 +777,7 @@ contains
             do k = xstV(3), xenV(3)
                do j = xstV(2), xenV(2)
                   do i = xstV(1), xenV(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipV + 1, (j - 1)*jskipV + 1, (k - 1)*kskipV + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipV + 1, (j - 1) * jskipV + 1, (k - 1) * kskipV + 1)
                   end do
                end do
             end do
@@ -785,7 +785,7 @@ contains
             do k = xstV(3), xenV(3)
                do j = xstV(2), xenV(2)
                   do i = xstV(1), xenV(1)
-                     wk(i, j, k) = wk2(i*iskipV, j*jskipV, k*kskipV)
+                     wk(i, j, k) = wk2(i * iskipV, j * jskipV, k * kskipV)
                   end do
                end do
             end do
@@ -799,7 +799,7 @@ contains
             do k = ystV(3), yenV(3)
                do j = ystV(2), yenV(2)
                   do i = ystV(1), yenV(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipV + 1, (j - 1)*jskipV + 1, (k - 1)*kskipV + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipV + 1, (j - 1) * jskipV + 1, (k - 1) * kskipV + 1)
                   end do
                end do
             end do
@@ -807,7 +807,7 @@ contains
             do k = ystV(3), yenV(3)
                do j = ystV(2), yenV(2)
                   do i = ystV(1), yenV(1)
-                     wk(i, j, k) = wk2(i*iskipV, j*jskipV, k*kskipV)
+                     wk(i, j, k) = wk2(i * iskipV, j * jskipV, k * kskipV)
                   end do
                end do
             end do
@@ -821,7 +821,7 @@ contains
             do k = zstV(3), zenV(3)
                do j = zstV(2), zenV(2)
                   do i = zstV(1), zenV(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipV + 1, (j - 1)*jskipV + 1, (k - 1)*kskipV + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipV + 1, (j - 1) * jskipV + 1, (k - 1) * kskipV + 1)
                   end do
                end do
             end do
@@ -829,7 +829,7 @@ contains
             do k = zstV(3), zenV(3)
                do j = zstV(2), zenV(2)
                   do i = zstV(1), zenV(1)
-                     wk(i, j, k) = wk2(i*iskipV, j*jskipV, k*kskipV)
+                     wk(i, j, k) = wk2(i * iskipV, j * jskipV, k * kskipV)
                   end do
                end do
             end do
@@ -862,7 +862,7 @@ contains
             do k = xstP(3), xenP(3)
                do j = xstP(2), xenP(2)
                   do i = xstP(1), xenP(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipP + 1, (j - 1)*jskipP + 1, (k - 1)*kskipP + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipP + 1, (j - 1) * jskipP + 1, (k - 1) * kskipP + 1)
                   end do
                end do
             end do
@@ -870,7 +870,7 @@ contains
             do k = xstP(3), xenP(3)
                do j = xstP(2), xenP(2)
                   do i = xstP(1), xenP(1)
-                     wk(i, j, k) = wk2(i*iskipP, j*jskipP, k*kskipP)
+                     wk(i, j, k) = wk2(i * iskipP, j * jskipP, k * kskipP)
                   end do
                end do
             end do
@@ -884,7 +884,7 @@ contains
             do k = ystP(3), yenP(3)
                do j = ystP(2), yenP(2)
                   do i = ystP(1), yenP(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipP + 1, (j - 1)*jskipP + 1, (k - 1)*kskipP + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipP + 1, (j - 1) * jskipP + 1, (k - 1) * kskipP + 1)
                   end do
                end do
             end do
@@ -892,7 +892,7 @@ contains
             do k = ystP(3), yenP(3)
                do j = ystP(2), yenP(2)
                   do i = ystP(1), yenP(1)
-                     wk(i, j, k) = wk2(i*iskipP, j*jskipP, k*kskipP)
+                     wk(i, j, k) = wk2(i * iskipP, j * jskipP, k * kskipP)
                   end do
                end do
             end do
@@ -906,7 +906,7 @@ contains
             do k = zstP(3), zenP(3)
                do j = zstP(2), zenP(2)
                   do i = zstP(1), zenP(1)
-                     wk(i, j, k) = wk2((i - 1)*iskipP + 1, (j - 1)*jskipP + 1, (k - 1)*kskipP + 1)
+                     wk(i, j, k) = wk2((i - 1) * iskipP + 1, (j - 1) * jskipP + 1, (k - 1) * kskipP + 1)
                   end do
                end do
             end do
@@ -914,7 +914,7 @@ contains
             do k = zstP(3), zenP(3)
                do j = zstP(2), zenP(2)
                   do i = zstP(1), zenP(1)
-                     wk(i, j, k) = wk2(i*iskipP, j*jskipP, k*kskipP)
+                     wk(i, j, k) = wk2(i * iskipP, j * jskipP, k * kskipP)
                   end do
                end do
             end do
@@ -1005,8 +1005,8 @@ contains
       integer data1, proc, st(0:proc - 1), en(0:proc - 1), sz(0:proc - 1)
       integer i, size1, nl, nu
 
-      size1 = data1/proc
-      nu = data1 - size1*proc
+      size1 = data1 / proc
+      nu = data1 - size1 * proc
       nl = proc - nu
       st(0) = 1
       sz(0) = size1
@@ -1082,8 +1082,8 @@ contains
       ! MPI_ALLTOALLV buffer information
 
       do i = 0, dims(1) - 1
-         decomp%x1cnts(i) = decomp%x1dist(i)*decomp%xsz(2)*decomp%xsz(3)
-         decomp%y1cnts(i) = decomp%ysz(1)*decomp%y1dist(i)*decomp%ysz(3)
+         decomp%x1cnts(i) = decomp%x1dist(i) * decomp%xsz(2) * decomp%xsz(3)
+         decomp%y1cnts(i) = decomp%ysz(1) * decomp%y1dist(i) * decomp%ysz(3)
          if (i == 0) then
             decomp%x1disp(i) = 0  ! displacement is 0-based index
             decomp%y1disp(i) = 0
@@ -1094,8 +1094,8 @@ contains
       end do
 
       do i = 0, dims(2) - 1
-         decomp%y2cnts(i) = decomp%ysz(1)*decomp%y2dist(i)*decomp%ysz(3)
-         decomp%z2cnts(i) = decomp%zsz(1)*decomp%zsz(2)*decomp%z2dist(i)
+         decomp%y2cnts(i) = decomp%ysz(1) * decomp%y2dist(i) * decomp%ysz(3)
+         decomp%z2cnts(i) = decomp%zsz(1) * decomp%zsz(2) * decomp%z2dist(i)
          if (i == 0) then
             decomp%y2disp(i) = 0  ! displacement is 0-based index
             decomp%z2disp(i) = 0
@@ -1117,12 +1117,12 @@ contains
       ! For unevenly distributed data, pad smaller messages. Note the
       ! last blocks along pencils always get assigned more mesh points
       ! for X <=> Y transposes
-      decomp%x1count = decomp%x1dist(dims(1) - 1)* &
-                       decomp%y1dist(dims(1) - 1)*decomp%xsz(3)
+      decomp%x1count = decomp%x1dist(dims(1) - 1) * &
+                       decomp%y1dist(dims(1) - 1) * decomp%xsz(3)
       decomp%y1count = decomp%x1count
       ! for Y <=> Z transposes
-      decomp%y2count = decomp%y2dist(dims(2) - 1)* &
-                       decomp%z2dist(dims(2) - 1)*decomp%zsz(1)
+      decomp%y2count = decomp%y2dist(dims(2) - 1) * &
+                       decomp%z2dist(dims(2) - 1) * decomp%zsz(1)
       decomp%z2count = decomp%y2count
 
       return

--- a/src/decomp_2d_init_fin.f90
+++ b/src/decomp_2d_init_fin.f90
@@ -74,7 +74,7 @@
         p_row = row
         p_col = col
      else
-        if (nproc /= p_row*p_col) then
+        if (nproc /= p_row * p_col) then
            errorcode = 1
            call decomp_2d_abort(__FILE__, __LINE__, errorcode, &
                                 'Invalid 2D processor grid - nproc /= p_row*p_col')
@@ -268,11 +268,11 @@
      call findfactor(iproc, factors, nfact)
      if (nrank == 0) write (*, *) 'factors: ', (factors(i), i=1, nfact)
 
-     i_best = nfact/2 + 1
+     i_best = nfact / 2 + 1
      col = factors(i_best)
 
      best_p_col = col
-     best_p_row = iproc/col
+     best_p_row = iproc / col
      if (nrank == 0) print *, 'p_row x p_col', best_p_row, best_p_col
      if ((best_p_col == 1) .and. (nrank == 0)) then
         print *, 'WARNING: current 2D DECOMP set-up might not work'

--- a/src/factor.f90
+++ b/src/factor.f90
@@ -35,7 +35,7 @@ contains
       m = int(sqrt(real(num)))
       nfact = 1
       do i = 1, m
-         if (num/i*i == num) then
+         if (num / i * i == num) then
             factors(nfact) = i
             nfact = nfact + 1
          end if
@@ -44,15 +44,15 @@ contains
 
       ! derive those > sqrt(num)
       if (factors(nfact)**2 /= num) then
-         do i = nfact + 1, 2*nfact
-            factors(i) = num/factors(2*nfact - i + 1)
+         do i = nfact + 1, 2 * nfact
+            factors(i) = num / factors(2 * nfact - i + 1)
          end do
-         nfact = nfact*2
+         nfact = nfact * 2
       else
-         do i = nfact + 1, 2*nfact - 1
-            factors(i) = num/factors(2*nfact - i)
+         do i = nfact + 1, 2 * nfact - 1
+            factors(i) = num / factors(2 * nfact - i)
          end do
-         nfact = nfact*2 - 1
+         nfact = nfact * 2 - 1
       end if
 
       return
@@ -76,7 +76,7 @@ contains
          if (mod(n, i) == 0) then
             factors(nfact) = i
             nfact = nfact + 1
-            n = n/i
+            n = n / i
          else
             i = i + 1
          end if

--- a/src/fft_common.f90
+++ b/src/fft_common.f90
@@ -128,9 +128,9 @@ subroutine fft_init_general(pencil, nx, ny, nz)
       call decomp_info_init(nx, ny, nz, ph)
    end if
    if (format == PHYSICAL_IN_X) then
-      call decomp_info_init(nx/2 + 1, ny, nz, sp)
+      call decomp_info_init(nx / 2 + 1, ny, nz, sp)
    else if (format == PHYSICAL_IN_Z) then
-      call decomp_info_init(nx, ny, nz/2 + 1, sp)
+      call decomp_info_init(nx, ny, nz / 2 + 1, sp)
    else
       call decomp_2d_abort(__FILE__, __LINE__, format, "Invalid value for format")
    end if

--- a/src/fft_cufft.f90
+++ b/src/fft_cufft.f90
@@ -65,7 +65,7 @@ module decomp_2d_fft
       istat = cufftMakePlanMany(plan1, 1, decomp%xsz(1), &
                                 decomp%xsz(1), 1, decomp%xsz(1), &
                                 decomp%xsz(1), 1, decomp%xsz(1), &
-                                cufft_type, decomp%xsz(2)*decomp%xsz(3), worksize)
+                                cufft_type, decomp%xsz(2) * decomp%xsz(3), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine c2c_1m_x_plan
@@ -117,9 +117,9 @@ module decomp_2d_fft
       istat = cufftSetAutoAllocation(plan1, 0)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftSetAutoAllocation")
       istat = cufftMakePlanMany(plan1, 1, decomp%zsz(3), &
-                                decomp%zsz(3), decomp%zsz(1)*decomp%zsz(2), 1, &
-                                decomp%zsz(3), decomp%zsz(1)*decomp%zsz(2), 1, &
-                                cufft_type, decomp%zsz(1)*decomp%zsz(2), worksize)
+                                decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
+                                decomp%zsz(3), decomp%zsz(1) * decomp%zsz(2), 1, &
+                                cufft_type, decomp%zsz(1) * decomp%zsz(2), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine c2c_1m_z_plan
@@ -146,7 +146,7 @@ module decomp_2d_fft
       istat = cufftMakePlanMany(plan1, 1, decomp_ph%xsz(1), &
                                 decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
                                 decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
-                                cufft_type, decomp_ph%xsz(2)*decomp_ph%xsz(3), worksize)
+                                cufft_type, decomp_ph%xsz(2) * decomp_ph%xsz(3), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine r2c_1m_x_plan
@@ -173,7 +173,7 @@ module decomp_2d_fft
       istat = cufftMakePlanMany(plan1, 1, decomp_ph%xsz(1), &
                                 decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
                                 decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
-                                cufft_type, decomp_ph%xsz(2)*decomp_ph%xsz(3), worksize)
+                                cufft_type, decomp_ph%xsz(2) * decomp_ph%xsz(3), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine c2r_1m_x_plan
@@ -198,9 +198,9 @@ module decomp_2d_fft
       istat = cufftSetAutoAllocation(plan1, 0)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftSetAutoAllocation")
       istat = cufftMakePlanMany(plan1, 1, decomp_ph%zsz(3), &
-                                decomp_ph%zsz(3), decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, &
-                                decomp_sp%zsz(3), decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, &
-                                cufft_type, decomp_ph%zsz(1)*decomp_ph%zsz(2), worksize)
+                                decomp_ph%zsz(3), decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, &
+                                decomp_sp%zsz(3), decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, &
+                                cufft_type, decomp_ph%zsz(1) * decomp_ph%zsz(2), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine r2c_1m_z_plan
@@ -225,9 +225,9 @@ module decomp_2d_fft
       istat = cufftSetAutoAllocation(plan1, 0)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftSetAutoAllocation")
       istat = cufftMakePlanMany(plan1, 1, decomp_ph%zsz(3), &
-                                decomp_sp%zsz(3), decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, &
-                                decomp_ph%zsz(3), decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, &
-                                cufft_type, decomp_ph%zsz(1)*decomp_ph%zsz(2), worksize)
+                                decomp_sp%zsz(3), decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, &
+                                decomp_ph%zsz(3), decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, &
+                                cufft_type, decomp_ph%zsz(1) * decomp_ph%zsz(2), worksize)
       if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cufftMakePlanMany")
 
    end subroutine c2r_1m_z_plan
@@ -369,7 +369,7 @@ module decomp_2d_fft
 
       end if
 #endif
-      cufft_ws = cufft_ws/sizeof(1._mytype)
+      cufft_ws = cufft_ws / sizeof(1._mytype)
       allocate (cufft_workspace(cufft_ws))
       do j = 1, 3
          do i = -1, 2
@@ -732,9 +732,9 @@ module decomp_2d_fft
          !call nvtxStartRange("Z r2c_1m_z")
 #ifdef DEBUG
          dim3d = shape(in_r)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(in_r(i, j, k))
                end do
             end do
@@ -753,9 +753,9 @@ module decomp_2d_fft
 #ifdef DEBUG
             write (*, *) 'c2c_1m_y'
             dim3d = shape(wk2_r2c)
-            do k = 1, dim3d(3), dim3d(3)/8
-               do j = 1, dim3d(2), dim3d(2)/8
-                  do i = 1, dim3d(1), dim3d(1)/8
+            do k = 1, dim3d(3), dim3d(3) / 8
+               do j = 1, dim3d(2), dim3d(2) / 8
+                  do i = 1, dim3d(1), dim3d(1) / 8
                      print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(wk2_r2c(i, j, k)), &
                         aimag(wk2_r2c(i, j, k))
                   end do
@@ -774,9 +774,9 @@ module decomp_2d_fft
 #ifdef DEBUG
             write (*, *) 'c2c_1m_y2'
             dim3d = shape(out_c)
-            do k = 1, dim3d(3), dim3d(3)/8
-               do j = 1, dim3d(2), dim3d(2)/8
-                  do i = 1, dim3d(1), dim3d(1)/8
+            do k = 1, dim3d(3), dim3d(3) / 8
+               do j = 1, dim3d(2), dim3d(2) / 8
+                  do i = 1, dim3d(1), dim3d(1) / 8
                      print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(out_c(i, j, k)), &
                         aimag(out_c(i, j, k))
                   end do
@@ -799,9 +799,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'c2c_1m_x'
          dim3d = shape(out_c)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(out_c(i, j, k)), &
                      aimag(out_c(i, j, k))
                end do
@@ -874,9 +874,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'Back Init c2c_1m_x line 788'
          dim3d = shape(in_c)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(in_c(i, j, k)), &
                      aimag(in_c(i, j, k))
                end do
@@ -891,9 +891,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'Back c2c_1m_x overwrite line 804'
          dim3d = shape(in_c)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(in_c(i, j, k)), &
                      aimag(in_c(i, j, k))
                end do
@@ -913,9 +913,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'Back2 c2c_1m_x line 821'
          dim3d = shape(wk1)
-         do k = 1, dim3d(3), dim3d(1)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(1) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(wk1(i, j, k)), &
                      aimag(wk1(i, j, k))
                end do
@@ -937,9 +937,9 @@ module decomp_2d_fft
 #ifdef DEBUG
             write (*, *) 'Back c2c_1m_y line 844'
             dim3d = shape(wk2_r2c)
-            do k = 1, dim3d(3), dim3d(3)/8
-               do j = 1, dim3d(2), dim3d(2)/8
-                  do i = 1, dim3d(1), dim3d(1)/8
+            do k = 1, dim3d(3), dim3d(3) / 8
+               do j = 1, dim3d(2), dim3d(2) / 8
+                  do i = 1, dim3d(1), dim3d(1) / 8
                      print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(wk2_r2c(i, j, k)), &
                         aimag(wk2_r2c(i, j, k))
                   end do
@@ -954,9 +954,9 @@ module decomp_2d_fft
 #ifdef DEBUG
             write (*, *) 'Back2 c2c_1m_y line 860'
             dim3d = shape(in_c)
-            do k = 1, dim3d(3), dim3d(3)/8
-               do j = 1, dim3d(2), dim3d(2)/8
-                  do i = 1, dim3d(1), dim3d(1)/8
+            do k = 1, dim3d(3), dim3d(3) / 8
+               do j = 1, dim3d(2), dim3d(2) / 8
+                  do i = 1, dim3d(1), dim3d(1) / 8
                      print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(in_c(i, j, k)), &
                         aimag(in_c(i, j, k))
                   end do
@@ -970,9 +970,9 @@ module decomp_2d_fft
 #ifdef DEBUG
             write (*, *) 'Back3 c2c_1m_y line 875'
             dim3d = shape(wk1)
-            do k = 1, dim3d(3), dim3d(3)/8
-               do j = 1, dim3d(2), dim3d(2)/8
-                  do i = 1, dim3d(1), dim3d(1)/8
+            do k = 1, dim3d(3), dim3d(3) / 8
+               do j = 1, dim3d(2), dim3d(2) / 8
+                  do i = 1, dim3d(1), dim3d(1) / 8
                      print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(wk1(i, j, k)), &
                         aimag(wk1(i, j, k))
                   end do
@@ -997,9 +997,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'Back2 after tr_y2z'
          dim3d = shape(wk13)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(wk13(i, j, k)), &
                      aimag(wk13(i, j, k))
                end do
@@ -1012,9 +1012,9 @@ module decomp_2d_fft
 #ifdef DEBUG
          write (*, *) 'Back2 c2r_1m_z out_r line 902'
          dim3d = shape(out_r)
-         do k = 1, dim3d(3), dim3d(3)/8
-            do j = 1, dim3d(2), dim3d(2)/8
-               do i = 1, dim3d(1), dim3d(1)/8
+         do k = 1, dim3d(3), dim3d(3) / 8
+            do j = 1, dim3d(2), dim3d(2) / 8
+               do i = 1, dim3d(1), dim3d(1) / 8
                   print "(i3,1x,i3,1x,i3,1x,e12.5,1x,e12.5)", i, j, k, real(out_r(i, j, k))
                end do
             end do

--- a/src/fft_fftw3.f90
+++ b/src/fft_fftw3.f90
@@ -65,12 +65,12 @@ module decomp_2d_fft
 
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft(plan1, 1, decomp%xsz(1), &
-                               decomp%xsz(2)*decomp%xsz(3), a1, decomp%xsz(1), 1, &
+                               decomp%xsz(2) * decomp%xsz(3), a1, decomp%xsz(1), 1, &
                                decomp%xsz(1), a1, decomp%xsz(1), 1, decomp%xsz(1), &
                                isign, plan_type)
 #else
       call sfftw_plan_many_dft(plan1, 1, decomp%xsz(1), &
-                               decomp%xsz(2)*decomp%xsz(3), a1, decomp%xsz(1), 1, &
+                               decomp%xsz(2) * decomp%xsz(3), a1, decomp%xsz(1), 1, &
                                decomp%xsz(1), a1, decomp%xsz(1), 1, decomp%xsz(1), &
                                isign, plan_type)
 #endif
@@ -126,14 +126,14 @@ module decomp_2d_fft
 
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft(plan1, 1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), a1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), 1, a1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), 1, isign, plan_type)
+                               decomp%zsz(1) * decomp%zsz(2), a1, decomp%zsz(3), &
+                               decomp%zsz(1) * decomp%zsz(2), 1, a1, decomp%zsz(3), &
+                               decomp%zsz(1) * decomp%zsz(2), 1, isign, plan_type)
 #else
       call sfftw_plan_many_dft(plan1, 1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), a1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), 1, a1, decomp%zsz(3), &
-                               decomp%zsz(1)*decomp%zsz(2), 1, isign, plan_type)
+                               decomp%zsz(1) * decomp%zsz(2), a1, decomp%zsz(3), &
+                               decomp%zsz(1) * decomp%zsz(2), 1, a1, decomp%zsz(3), &
+                               decomp%zsz(1) * decomp%zsz(2), 1, isign, plan_type)
 #endif
 
       deallocate (a1)
@@ -157,12 +157,12 @@ module decomp_2d_fft
       allocate (a2(decomp_sp%xsz(1), decomp_sp%xsz(2), decomp_sp%xsz(3)))
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft_r2c(plan1, 1, decomp_ph%xsz(1), &
-                                   decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
+                                   decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
                                    decomp_ph%xsz(1), a2, decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
                                    plan_type)
 #else
       call sfftw_plan_many_dft_r2c(plan1, 1, decomp_ph%xsz(1), &
-                                   decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
+                                   decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
                                    decomp_ph%xsz(1), a2, decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
                                    plan_type)
 #endif
@@ -187,12 +187,12 @@ module decomp_2d_fft
       allocate (a2(decomp_ph%xsz(1), decomp_ph%xsz(2), decomp_ph%xsz(3)))
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft_c2r(plan1, 1, decomp_ph%xsz(1), &
-                                   decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
+                                   decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
                                    decomp_sp%xsz(1), a2, decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
                                    plan_type)
 #else
       call sfftw_plan_many_dft_c2r(plan1, 1, decomp_ph%xsz(1), &
-                                   decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
+                                   decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
                                    decomp_sp%xsz(1), a2, decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
                                    plan_type)
 #endif
@@ -217,14 +217,14 @@ module decomp_2d_fft
       allocate (a2(decomp_sp%zsz(1), decomp_sp%zsz(2), decomp_sp%zsz(3)))
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft_r2c(plan1, 1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
-                                   decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, plan_type)
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
+                                   decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, plan_type)
 #else
       call sfftw_plan_many_dft_r2c(plan1, 1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
-                                   decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, plan_type)
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
+                                   decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, plan_type)
 #endif
       deallocate (a1, a2)
 
@@ -248,14 +248,14 @@ module decomp_2d_fft
 
 #ifdef DOUBLE_PREC
       call dfftw_plan_many_dft_c2r(plan1, 1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
-                                   decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, plan_type)
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
+                                   decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, plan_type)
 #else
       call sfftw_plan_many_dft_c2r(plan1, 1, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
-                                   decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
-                                   decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, plan_type)
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
+                                   decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
+                                   decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, plan_type)
 #endif
       deallocate (a1, a2)
 

--- a/src/fft_fftw3_f03.f90
+++ b/src/fft_fftw3_f03.f90
@@ -156,9 +156,9 @@ contains
          call decomp_info_init(nx, ny, nz, ph)
       end if
       if (format == PHYSICAL_IN_X) then
-         call decomp_info_init(nx/2 + 1, ny, nz, sp)
+         call decomp_info_init(nx / 2 + 1, ny, nz, sp)
       else if (format == PHYSICAL_IN_Z) then
-         call decomp_info_init(nx, ny, nz/2 + 1, sp)
+         call decomp_info_init(nx, ny, nz / 2 + 1, sp)
       else
          call decomp_2d_abort(__FILE__, __LINE__, format, "Invalid value for format")
       end if
@@ -167,7 +167,7 @@ contains
       ! Allocate the workspace fo intermediate y-pencil data
       ! The largest memory block needed is the one for c2c transforms
       !
-      sz = ph%ysz(1)*ph%ysz(2)*ph%ysz(3)
+      sz = ph%ysz(1) * ph%ysz(2) * ph%ysz(3)
       wk2_c2c_p = fftw_alloc_complex(sz)
       call c_f_pointer(wk2_c2c_p, wk2_c2c, [ph%ysz(1), ph%ysz(2), ph%ysz(3)])
       !
@@ -186,11 +186,11 @@ contains
       ! transpose_y_to_z(wk2_r2c, wk13, sp)
       !
       if (format == PHYSICAL_IN_X) then
-         sz = sp%xsz(1)*sp%xsz(2)*sp%xsz(3)
+         sz = sp%xsz(1) * sp%xsz(2) * sp%xsz(3)
          wk13_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk13_p, wk13, [sp%xsz(1), sp%xsz(2), sp%xsz(3)])
       else if (format == PHYSICAL_IN_Z) then
-         sz = sp%zsz(1)*sp%zsz(2)*sp%zsz(3)
+         sz = sp%zsz(1) * sp%zsz(2) * sp%zsz(3)
          wk13_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk13_p, wk13, [sp%zsz(1), sp%zsz(2), sp%zsz(3)])
       end if
@@ -319,19 +319,19 @@ contains
       type(C_PTR) :: a1_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp%xsz(1)*decomp%xsz(2)*decomp%xsz(3)
+      sz = decomp%xsz(1) * decomp%xsz(2) * decomp%xsz(3)
       a1_p = fftw_alloc_complex(sz)
       call c_f_pointer(a1_p, a1, [decomp%xsz(1), decomp%xsz(2), decomp%xsz(3)])
       call c_f_pointer(a1_p, a1o, [decomp%xsz(1), decomp%xsz(2), decomp%xsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft(1, decomp%xsz(1), &
-                                 decomp%xsz(2)*decomp%xsz(3), a1, decomp%xsz(1), 1, &
+                                 decomp%xsz(2) * decomp%xsz(3), a1, decomp%xsz(1), 1, &
                                  decomp%xsz(1), a1o, decomp%xsz(1), 1, decomp%xsz(1), &
                                  isign, plan_type)
 #else
       plan1 = fftwf_plan_many_dft(1, decomp%xsz(1), &
-                                  decomp%xsz(2)*decomp%xsz(3), a1, decomp%xsz(1), 1, &
+                                  decomp%xsz(2) * decomp%xsz(3), a1, decomp%xsz(1), 1, &
                                   decomp%xsz(1), a1o, decomp%xsz(1), 1, decomp%xsz(1), &
                                   isign, plan_type)
 #endif
@@ -362,7 +362,7 @@ contains
 
       ! Due to memory pattern of 3D arrays, 1D FFTs along Y have to be
       ! done one Z-plane at a time. So plan for 2D data sets here.
-      sz = decomp%ysz(1)*decomp%ysz(2)
+      sz = decomp%ysz(1) * decomp%ysz(2)
       a1_p = fftw_alloc_complex(sz)
       call c_f_pointer(a1_p, a1, [decomp%ysz(1), decomp%ysz(2)])
       call c_f_pointer(a1_p, a1o, [decomp%ysz(1), decomp%ysz(2)])
@@ -401,21 +401,21 @@ contains
       type(C_PTR) :: a1_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp%zsz(1)*decomp%zsz(2)*decomp%zsz(3)
+      sz = decomp%zsz(1) * decomp%zsz(2) * decomp%zsz(3)
       a1_p = fftw_alloc_complex(sz)
       call c_f_pointer(a1_p, a1, [decomp%zsz(1), decomp%zsz(2), decomp%zsz(3)])
       call c_f_pointer(a1_p, a1o, [decomp%zsz(1), decomp%zsz(2), decomp%zsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft(1, decomp%zsz(3), &
-                                 decomp%zsz(1)*decomp%zsz(2), a1, decomp%zsz(3), &
-                                 decomp%zsz(1)*decomp%zsz(2), 1, a1o, decomp%zsz(3), &
-                                 decomp%zsz(1)*decomp%zsz(2), 1, isign, plan_type)
+                                 decomp%zsz(1) * decomp%zsz(2), a1, decomp%zsz(3), &
+                                 decomp%zsz(1) * decomp%zsz(2), 1, a1o, decomp%zsz(3), &
+                                 decomp%zsz(1) * decomp%zsz(2), 1, isign, plan_type)
 #else
       plan1 = fftwf_plan_many_dft(1, decomp%zsz(3), &
-                                  decomp%zsz(1)*decomp%zsz(2), a1, decomp%zsz(3), &
-                                  decomp%zsz(1)*decomp%zsz(2), 1, a1o, decomp%zsz(3), &
-                                  decomp%zsz(1)*decomp%zsz(2), 1, isign, plan_type)
+                                  decomp%zsz(1) * decomp%zsz(2), a1, decomp%zsz(3), &
+                                  decomp%zsz(1) * decomp%zsz(2), 1, a1o, decomp%zsz(3), &
+                                  decomp%zsz(1) * decomp%zsz(2), 1, isign, plan_type)
 #endif
 
       call fftw_free(a1_p)
@@ -437,23 +437,23 @@ contains
       type(C_PTR) :: a1_p, a2_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp_ph%xsz(1)*decomp_ph%xsz(2)*decomp_ph%xsz(3)
+      sz = decomp_ph%xsz(1) * decomp_ph%xsz(2) * decomp_ph%xsz(3)
       a1_p = fftw_alloc_real(sz)
       call c_f_pointer(a1_p, a1, &
                        [decomp_ph%xsz(1), decomp_ph%xsz(2), decomp_ph%xsz(3)])
-      sz = decomp_sp%xsz(1)*decomp_sp%xsz(2)*decomp_sp%xsz(3)
+      sz = decomp_sp%xsz(1) * decomp_sp%xsz(2) * decomp_sp%xsz(3)
       a2_p = fftw_alloc_complex(sz)
       call c_f_pointer(a2_p, a2, &
                        [decomp_sp%xsz(1), decomp_sp%xsz(2), decomp_sp%xsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft_r2c(1, decomp_ph%xsz(1), &
-                                     decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
+                                     decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
                                      decomp_ph%xsz(1), a2, decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
                                      plan_type)
 #else
       plan1 = fftwf_plan_many_dft_r2c(1, decomp_ph%xsz(1), &
-                                      decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
+                                      decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_ph%xsz(1), 1, &
                                       decomp_ph%xsz(1), a2, decomp_sp%xsz(1), 1, decomp_sp%xsz(1), &
                                       plan_type)
 #endif
@@ -478,23 +478,23 @@ contains
       type(C_PTR) :: a1_p, a2_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp_sp%xsz(1)*decomp_sp%xsz(2)*decomp_sp%xsz(3)
+      sz = decomp_sp%xsz(1) * decomp_sp%xsz(2) * decomp_sp%xsz(3)
       a1_p = fftw_alloc_complex(sz)
       call c_f_pointer(a1_p, a1, &
                        [decomp_sp%xsz(1), decomp_sp%xsz(2), decomp_sp%xsz(3)])
-      sz = decomp_ph%xsz(1)*decomp_ph%xsz(2)*decomp_ph%xsz(3)
+      sz = decomp_ph%xsz(1) * decomp_ph%xsz(2) * decomp_ph%xsz(3)
       a2_p = fftw_alloc_real(sz)
       call c_f_pointer(a2_p, a2, &
                        [decomp_ph%xsz(1), decomp_ph%xsz(2), decomp_ph%xsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft_c2r(1, decomp_ph%xsz(1), &
-                                     decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
+                                     decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
                                      decomp_sp%xsz(1), a2, decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
                                      plan_type)
 #else
       plan1 = fftwf_plan_many_dft_c2r(1, decomp_ph%xsz(1), &
-                                      decomp_ph%xsz(2)*decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
+                                      decomp_ph%xsz(2) * decomp_ph%xsz(3), a1, decomp_sp%xsz(1), 1, &
                                       decomp_sp%xsz(1), a2, decomp_ph%xsz(1), 1, decomp_ph%xsz(1), &
                                       plan_type)
 #endif
@@ -519,25 +519,25 @@ contains
       type(C_PTR) :: a1_p, a2_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp_ph%zsz(1)*decomp_ph%zsz(2)*decomp_ph%zsz(3)
+      sz = decomp_ph%zsz(1) * decomp_ph%zsz(2) * decomp_ph%zsz(3)
       a1_p = fftw_alloc_real(sz)
       call c_f_pointer(a1_p, a1, &
                        [decomp_ph%zsz(1), decomp_ph%zsz(2), decomp_ph%zsz(3)])
-      sz = decomp_sp%zsz(1)*decomp_sp%zsz(2)*decomp_sp%zsz(3)
+      sz = decomp_sp%zsz(1) * decomp_sp%zsz(2) * decomp_sp%zsz(3)
       a2_p = fftw_alloc_complex(sz)
       call c_f_pointer(a2_p, a2, &
                        [decomp_sp%zsz(1), decomp_sp%zsz(2), decomp_sp%zsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft_r2c(1, decomp_ph%zsz(3), &
-                                     decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
-                                     decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
-                                     decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, plan_type)
+                                     decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
+                                     decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
+                                     decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, plan_type)
 #else
       plan1 = fftwf_plan_many_dft_r2c(1, decomp_ph%zsz(3), &
-                                      decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
-                                      decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
-                                      decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, plan_type)
+                                      decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_ph%zsz(3), &
+                                      decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, a2, decomp_sp%zsz(3), &
+                                      decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, plan_type)
 #endif
 
       call fftw_free(a1_p)
@@ -560,25 +560,25 @@ contains
       type(C_PTR) :: a1_p, a2_p
       integer(C_SIZE_T) :: sz
 
-      sz = decomp_sp%zsz(1)*decomp_sp%zsz(2)*decomp_sp%zsz(3)
+      sz = decomp_sp%zsz(1) * decomp_sp%zsz(2) * decomp_sp%zsz(3)
       a1_p = fftw_alloc_complex(sz)
       call c_f_pointer(a1_p, a1, &
                        [decomp_sp%zsz(1), decomp_sp%zsz(2), decomp_sp%zsz(3)])
-      sz = decomp_ph%zsz(1)*decomp_ph%zsz(2)*decomp_ph%zsz(3)
+      sz = decomp_ph%zsz(1) * decomp_ph%zsz(2) * decomp_ph%zsz(3)
       a2_p = fftw_alloc_real(sz)
       call c_f_pointer(a2_p, a2, &
                        [decomp_ph%zsz(1), decomp_ph%zsz(2), decomp_ph%zsz(3)])
 
 #ifdef DOUBLE_PREC
       plan1 = fftw_plan_many_dft_c2r(1, decomp_ph%zsz(3), &
-                                     decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
-                                     decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
-                                     decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, plan_type)
+                                     decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
+                                     decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
+                                     decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, plan_type)
 #else
       plan1 = fftwf_plan_many_dft_c2r(1, decomp_ph%zsz(3), &
-                                      decomp_ph%zsz(1)*decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
-                                      decomp_sp%zsz(1)*decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
-                                      decomp_ph%zsz(1)*decomp_ph%zsz(2), 1, plan_type)
+                                      decomp_ph%zsz(1) * decomp_ph%zsz(2), a1, decomp_sp%zsz(3), &
+                                      decomp_sp%zsz(1) * decomp_sp%zsz(2), 1, a2, decomp_ph%zsz(3), &
+                                      decomp_ph%zsz(1) * decomp_ph%zsz(2), 1, plan_type)
 #endif
 
       call fftw_free(a1_p)
@@ -823,7 +823,7 @@ contains
 #ifdef OVERWRITE
          call c2c_1m_x(in, plan(isign, 1))
 #else
-         sz = ph%xsz(1)*ph%xsz(2)*ph%xsz(3)
+         sz = ph%xsz(1) * ph%xsz(2) * ph%xsz(3)
          wk1_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk1_p, wk1, [ph%xsz(1), ph%xsz(2), ph%xsz(3)])
          wk1 = in
@@ -867,7 +867,7 @@ contains
 #ifdef OVERWRITE
          call c2c_1m_z(in, plan(isign, 3))
 #else
-         sz = ph%zsz(1)*ph%zsz(2)*ph%zsz(3)
+         sz = ph%zsz(1) * ph%zsz(2) * ph%zsz(3)
          wk1_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk1_p, wk1, [ph%zsz(1), ph%zsz(2), ph%zsz(3)])
          wk1 = in
@@ -1003,7 +1003,7 @@ contains
 #ifdef OVERWRITE
          call c2c_1m_z(in_c, plan(2, 3))
 #else
-         sz = sp%zsz(1)*sp%zsz(2)*sp%zsz(3)
+         sz = sp%zsz(1) * sp%zsz(2) * sp%zsz(3)
          wk1_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk1_p, wk1, [sp%zsz(1), sp%zsz(2), sp%zsz(3)])
          wk1 = in_c
@@ -1032,7 +1032,7 @@ contains
 #ifdef OVERWRITE
          call c2c_1m_x(in_c, plan(2, 1))
 #else
-         sz = sp%xsz(1)*sp%xsz(2)*sp%xsz(3)
+         sz = sp%xsz(1) * sp%xsz(2) * sp%xsz(3)
          wk1_p = fftw_alloc_complex(sz)
          call c_f_pointer(wk1_p, wk1, [sp%xsz(1), sp%xsz(2), sp%xsz(3)])
          wk1 = in_c

--- a/src/fft_generic.f90
+++ b/src/fft_generic.f90
@@ -260,7 +260,7 @@ module decomp_2d_fft
          do j = 1, d2
             ! Glassman's FFT is c2c only,
             ! needing some pre- and post-processing for c2r
-            do i = 1, d1/2 + 1
+            do i = 1, d1 / 2 + 1
                buf(i) = input(i, j, k)
             end do
             ! expanding to a full-size complex array
@@ -270,7 +270,7 @@ module decomp_2d_fft
             ! For even N, the storage is:
             !  1, 2, ...... N/2  , N/2+1
             !     N, ...... N/2+2  again a(i) conjugate of a(N+2-i)
-            do i = d1/2 + 2, d1
+            do i = d1 / 2 + 2, d1
                buf(i) = conjg(buf(d1 + 2 - i))
             end do
             call spcfft(buf, d1, 1, scratch)
@@ -305,10 +305,10 @@ module decomp_2d_fft
       !$acc parallel loop gang vector collapse(2) private(buf, scratch)
       do j = 1, d2
          do i = 1, d1
-            do k = 1, d3/2 + 1
+            do k = 1, d3 / 2 + 1
                buf(k) = input(i, j, k)
             end do
-            do k = d3/2 + 2, d3
+            do k = d3 / 2 + 2, d3
                buf(k) = conjg(buf(d3 + 2 - k))
             end do
             call spcfft(buf, d3, 1, scratch)

--- a/src/fft_mkl.f90
+++ b/src/fft_mkl.f90
@@ -90,7 +90,7 @@ module decomp_2d_fft
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiCreateDescriptor")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
-                            decomp%xsz(2)*decomp%xsz(3))
+                            decomp%xsz(2) * decomp%xsz(3))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
 #ifdef OVERWRITE
       status = DftiSetValue(desc, DFTI_PLACEMENT, DFTI_INPLACE)
@@ -178,14 +178,14 @@ module decomp_2d_fft
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
-                            decomp%zsz(1)*decomp%zsz(2))
+                            decomp%zsz(1) * decomp%zsz(2))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_INPUT_DISTANCE, 1)
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_OUTPUT_DISTANCE, 1)
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       strides(1) = 0
-      strides(2) = decomp%zsz(1)*decomp%zsz(2)
+      strides(2) = decomp%zsz(1) * decomp%zsz(2)
       status = DftiSetValue(desc, DFTI_INPUT_STRIDES, strides)
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_OUTPUT_STRIDES, strides)
@@ -218,7 +218,7 @@ module decomp_2d_fft
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiCreateDescriptor")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
-                            decomp_ph%xsz(2)*decomp_ph%xsz(3))
+                            decomp_ph%xsz(2) * decomp_ph%xsz(3))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE, &
                             DFTI_COMPLEX_COMPLEX)
@@ -268,7 +268,7 @@ module decomp_2d_fft
 #endif
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiCreateDescriptor")
       status = DftiSetValue(desc, DFTI_NUMBER_OF_TRANSFORMS, &
-                            decomp_ph%zsz(1)*decomp_ph%zsz(2))
+                            decomp_ph%zsz(1) * decomp_ph%zsz(2))
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       status = DftiSetValue(desc, DFTI_CONJUGATE_EVEN_STORAGE, &
                             DFTI_COMPLEX_COMPLEX)
@@ -280,14 +280,14 @@ module decomp_2d_fft
       status = DftiSetValue(desc, DFTI_OUTPUT_DISTANCE, 1)
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
       strides(1) = 0
-      strides(2) = decomp_ph%zsz(1)*decomp_ph%zsz(2)
+      strides(2) = decomp_ph%zsz(1) * decomp_ph%zsz(2)
       if (direction == -1) then
          status = DftiSetValue(desc, DFTI_INPUT_STRIDES, strides)
       else if (direction == 1) then
          status = DftiSetValue(desc, DFTI_OUTPUT_STRIDES, strides)
       end if
       if (status /= 0) call decomp_2d_abort(__FILE__, __LINE__, status, "DftiSetValue")
-      strides(2) = decomp_sp%zsz(1)*decomp_sp%zsz(2)
+      strides(2) = decomp_sp%zsz(1) * decomp_sp%zsz(2)
       if (direction == -1) then
          status = DftiSetValue(desc, DFTI_OUTPUT_STRIDES, strides)
       else if (direction == 1) then

--- a/src/glassman.f90
+++ b/src/glassman.f90
@@ -52,12 +52,12 @@ contains
       INU = .TRUE.
 
       DO WHILE (B > 1)
-         A = C*A
+         A = C * A
          C = 2
          DO WHILE (MOD(B, C) /= 0)
             C = C + 1
          END DO
-         B = B/C
+         B = B / C
          IF (INU) THEN
             CALL SPCPFT(A, B, C, U, WORK, ISIGN)
          ELSE
@@ -90,7 +90,7 @@ contains
       COMPLEX(mytype), INTENT(OUT) :: UOUT(B, A, C)
       COMPLEX(mytype) :: DELTA, OMEGA, SUM
 
-      ANGLE = 6.28318530717958_mytype/REAL(A*C, kind=mytype)
+      ANGLE = 6.28318530717958_mytype / REAL(A * C, kind=mytype)
       OMEGA = CMPLX(1.0, 0.0, kind=mytype)
 
       IF (ISIGN == 1) THEN
@@ -105,11 +105,11 @@ contains
                SUM = UIN(IB, C, IA)
                DO JCR = 2, C
                   JC = C + 1 - JCR
-                  SUM = UIN(IB, JC, IA) + OMEGA*SUM
+                  SUM = UIN(IB, JC, IA) + OMEGA * SUM
                END DO
                UOUT(IB, IA, IC) = SUM
             END DO
-            OMEGA = DELTA*OMEGA
+            OMEGA = DELTA * OMEGA
          END DO
       END DO
 
@@ -148,7 +148,7 @@ contains
             end do
             call spcfft(buf, nx, -1, scratch)
             ! simply drop the redundant part of the complex output
-            do i = 1, nx/2 + 1
+            do i = 1, nx / 2 + 1
                out_c(i, j, k) = buf(i)
             end do
          end do
@@ -156,7 +156,7 @@ contains
 
       ! ===== 1D FFTs in Y =====
       do k = 1, nz
-         do i = 1, nx/2 + 1
+         do i = 1, nx / 2 + 1
             do j = 1, ny
                buf(j) = out_c(i, j, k)
             end do
@@ -169,7 +169,7 @@ contains
 
       ! ===== 1D FFTs in Z =====
       do j = 1, ny
-         do i = 1, nx/2 + 1
+         do i = 1, nx / 2 + 1
             do k = 1, nz
                buf(k) = out_c(i, j, k)
             end do

--- a/src/halo_common.f90
+++ b/src/halo_common.f90
@@ -203,9 +203,9 @@
        else
           tag_n = coord(1) + 1
        end if
-       icount = s3 + 2*level
-       ilength = level*s1
-       ijump = s1*(s2 + 2*level)
+       icount = s3 + 2 * level
+       ilength = level * s1
+       ijump = s1 * (s2 + 2 * level)
        call MPI_TYPE_VECTOR(icount, ilength, ijump, &
                             data_type, halo12, ierror)
        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
@@ -254,7 +254,7 @@
        else
           tag_t = coord(2) + 1
        end if
-       icount = (s1*(s2 + 2*level))*level
+       icount = (s1 * (s2 + 2 * level)) * level
        ! receive from bottom
        call MPI_IRECV(out(xs, ys, zs), icount, data_type, &
                       neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
@@ -309,9 +309,9 @@
        else
           tag_e = coord(1) + 1
        end if
-       icount = s2*(s3 + 2*level)
+       icount = s2 * (s3 + 2 * level)
        ilength = level
-       ijump = s1 + 2*level
+       ijump = s1 + 2 * level
        call MPI_TYPE_VECTOR(icount, ilength, ijump, &
                             data_type, halo21, ierror)
        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
@@ -363,7 +363,7 @@
        else
           tag_t = coord(2) + 1
        end if
-       icount = (s2*(s1 + 2*level))*level
+       icount = (s2 * (s1 + 2 * level)) * level
        ! receive from bottom
        call MPI_IRECV(out(xs, ys, zs), icount, data_type, &
                       neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
@@ -417,9 +417,9 @@
        else
           tag_e = coord(1) + 1
        end if
-       icount = (s2 + 2*level)*s3
+       icount = (s2 + 2 * level) * s3
        ilength = level
-       ijump = s1 + 2*level
+       ijump = s1 + 2 * level
        call MPI_TYPE_VECTOR(icount, ilength, ijump, &
                             data_type, halo31, ierror)
        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
@@ -466,8 +466,8 @@
           tag_n = coord(2) + 1
        end if
        icount = s3
-       ilength = level*(s1 + 2*level)
-       ijump = (s1 + 2*level)*(s2 + 2*level)
+       ilength = level * (s1 + 2 * level)
+       ijump = (s1 + 2 * level) * (s2 + 2 * level)
        call MPI_TYPE_VECTOR(icount, ilength, ijump, &
                             data_type, halo32, ierror)
        if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")

--- a/src/io.f90
+++ b/src/io.f90
@@ -355,14 +355,14 @@ contains
          if (read_reduce_prec) then
             allocate (varsingle(xstV(1):xenV(1), xstV(2):xenV(2), xstV(3):xenV(3)))
             call MPI_FILE_READ_ALL(fh, varsingle, &
-                                   subsizes(1)*subsizes(2)*subsizes(3), &
+                                   subsizes(1) * subsizes(2) * subsizes(3), &
                                    data_type, MPI_STATUS_IGNORE, ierror)
             if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_READ_ALL")
             var = real(varsingle, mytype)
             deallocate (varsingle)
          else
             call MPI_FILE_READ_ALL(fh, var, &
-                                   subsizes(1)*subsizes(2)*subsizes(3), &
+                                   subsizes(1) * subsizes(2) * subsizes(3), &
                                    data_type, MPI_STATUS_IGNORE, ierror)
             if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_READ_ALL")
          end if
@@ -370,9 +370,9 @@ contains
          if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
 
          disp = disp + int(sizes(1), kind=MPI_OFFSET_KIND) &
-                *int(sizes(2), kind=MPI_OFFSET_KIND) &
-                *int(sizes(3), kind=MPI_OFFSET_KIND) &
-                *int(disp_bytes, kind=MPI_OFFSET_KIND)
+                * int(sizes(2), kind=MPI_OFFSET_KIND) &
+                * int(sizes(3), kind=MPI_OFFSET_KIND) &
+                * int(disp_bytes, kind=MPI_OFFSET_KIND)
       end associate
 
       if (opened_new) then
@@ -668,7 +668,7 @@ contains
                               MPI_STATUS_IGNORE, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+             * int(mytype_bytes, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine write_scalar_real
@@ -696,8 +696,8 @@ contains
                               MPI_STATUS_IGNORE, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(mytype_bytes, kind=MPI_OFFSET_KIND) &
-             *2_MPI_OFFSET_KIND
+             * int(mytype_bytes, kind=MPI_OFFSET_KIND) &
+             * 2_MPI_OFFSET_KIND
 
       return
    end subroutine write_scalar_complex
@@ -727,7 +727,7 @@ contains
       call MPI_TYPE_SIZE(MPI_INTEGER, m, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_SIZE")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(m, kind=MPI_OFFSET_KIND)
+             * int(m, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine write_scalar_integer
@@ -757,7 +757,7 @@ contains
       call MPI_TYPE_SIZE(MPI_LOGICAL, m, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_SIZE")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(m, kind=MPI_OFFSET_KIND)
+             * int(m, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine write_scalar_logical
@@ -787,7 +787,7 @@ contains
                              MPI_STATUS_IGNORE, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_READ_ALL")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+             * int(mytype_bytes, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine read_scalar_real
@@ -810,8 +810,8 @@ contains
                              MPI_STATUS_IGNORE, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_READ_ALL")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(mytype_bytes, kind=MPI_OFFSET_KIND) &
-             *2_MPI_OFFSET_KIND
+             * int(mytype_bytes, kind=MPI_OFFSET_KIND) &
+             * 2_MPI_OFFSET_KIND
 
       return
    end subroutine read_scalar_complex
@@ -836,7 +836,7 @@ contains
       call MPI_TYPE_SIZE(MPI_INTEGER, m, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_SIZE")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(m, kind=MPI_OFFSET_KIND)
+             * int(m, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine read_scalar_integer
@@ -861,7 +861,7 @@ contains
       call MPI_TYPE_SIZE(MPI_LOGICAL, m, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_SIZE")
       disp = disp + int(n, kind=MPI_OFFSET_KIND) &
-             *int(m, kind=MPI_OFFSET_KIND)
+             * int(m, kind=MPI_OFFSET_KIND)
 
       return
    end subroutine read_scalar_logical
@@ -1312,22 +1312,22 @@ contains
                                 newtype, 'native', MPI_INFO_NULL, ierror)
          if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
          call MPI_FILE_WRITE_ALL(fh_registry(idx), varsingle, &
-                                 subsizes(1)*subsizes(2)*subsizes(3), &
+                                 subsizes(1) * subsizes(2) * subsizes(3), &
                                  real_type_single, MPI_STATUS_IGNORE, ierror)
       else
          call MPI_FILE_SET_VIEW(fh_registry(idx), fh_disp(idx), real_type, &
                                 newtype, 'native', MPI_INFO_NULL, ierror)
          if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
          call MPI_FILE_WRITE_ALL(fh_registry(idx), var, &
-                                 subsizes(1)*subsizes(2)*subsizes(3), &
+                                 subsizes(1) * subsizes(2) * subsizes(3), &
                                  real_type, MPI_STATUS_IGNORE, ierror)
       end if
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
 
       fh_disp(idx) = fh_disp(idx) + int(sizes(1), kind=MPI_OFFSET_KIND) &
-                     *int(sizes(2), kind=MPI_OFFSET_KIND) &
-                     *int(sizes(3), kind=MPI_OFFSET_KIND) &
-                     *int(disp_bytes, kind=MPI_OFFSET_KIND)
+                     * int(sizes(2), kind=MPI_OFFSET_KIND) &
+                     * int(sizes(3), kind=MPI_OFFSET_KIND) &
+                     * int(disp_bytes, kind=MPI_OFFSET_KIND)
 
       if (opened_new) then
          call decomp_2d_close_io(io_name, full_io_name)
@@ -1537,7 +1537,7 @@ contains
                              newtype, 'native', MPI_INFO_NULL, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
       call MPI_FILE_WRITE_ALL(fh, var, &
-                              subsizes(1)*subsizes(2)*subsizes(3)*subsizes(4), &
+                              subsizes(1) * subsizes(2) * subsizes(3) * subsizes(4), &
                               real_type, MPI_STATUS_IGNORE, ierror)
       if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
       call MPI_FILE_CLOSE(fh, ierror)
@@ -1750,7 +1750,7 @@ contains
                                 newtype, 'native', MPI_INFO_NULL, ierror)
          if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
          call MPI_FILE_WRITE_ALL(fh, wk, &
-                                 subsizes(1)*subsizes(2)*subsizes(3), &
+                                 subsizes(1) * subsizes(2) * subsizes(3), &
                                  data_type, MPI_STATUS_IGNORE, ierror)
          if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
          call MPI_FILE_CLOSE(fh, ierror)

--- a/src/io_read_inflow.f90
+++ b/src/io_read_inflow.f90
@@ -50,7 +50,7 @@ associate (fh => fh_registry(idx), &
                           newtype, 'native', MPI_INFO_NULL, ierror)
    if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
    call MPI_FILE_READ_ALL(fh, var, &
-                          subsizes(1)*subsizes(2)*subsizes(3), &
+                          subsizes(1) * subsizes(2) * subsizes(3), &
                           data_type, MPI_STATUS_IGNORE, ierror)
    if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_READ_ALL")
    call MPI_TYPE_FREE(newtype, ierror)
@@ -58,13 +58,13 @@ associate (fh => fh_registry(idx), &
 
    ! update displacement for the next read operation
    disp = disp + int(sizes(1), kind=MPI_OFFSET_KIND) &
-          *int(sizes(2), kind=MPI_OFFSET_KIND) &
-          *int(sizes(3), kind=MPI_OFFSET_KIND) &
-          *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+          * int(sizes(2), kind=MPI_OFFSET_KIND) &
+          * int(sizes(3), kind=MPI_OFFSET_KIND) &
+          * int(mytype_bytes, kind=MPI_OFFSET_KIND)
    if (data_type == complex_type) disp = disp + int(sizes(1), kind=MPI_OFFSET_KIND) &
-                                         *int(sizes(2), kind=MPI_OFFSET_KIND) &
-                                         *int(sizes(3), kind=MPI_OFFSET_KIND) &
-                                         *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+                                         * int(sizes(2), kind=MPI_OFFSET_KIND) &
+                                         * int(sizes(3), kind=MPI_OFFSET_KIND) &
+                                         * int(mytype_bytes, kind=MPI_OFFSET_KIND)
 end associate
 
 associate (vnm => varname) ! Silence unused argument

--- a/src/io_write_outflow.f90
+++ b/src/io_write_outflow.f90
@@ -50,7 +50,7 @@ associate (fh => fh_registry(idx), &
                           newtype, 'native', MPI_INFO_NULL, ierror)
    if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_SET_VIEW")
    call MPI_FILE_WRITE_ALL(fh, var, &
-                           subsizes(1)*subsizes(2)*subsizes(3), &
+                           subsizes(1) * subsizes(2) * subsizes(3), &
                            data_type, MPI_STATUS_IGNORE, ierror)
    if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_FILE_WRITE_ALL")
    call MPI_TYPE_FREE(newtype, ierror)
@@ -58,13 +58,13 @@ associate (fh => fh_registry(idx), &
 
    ! update displacement for the next write operation
    disp = disp + int(sizes(1), kind=MPI_OFFSET_KIND) &
-          *int(sizes(2), kind=MPI_OFFSET_KIND) &
-          *int(sizes(3), kind=MPI_OFFSET_KIND) &
-          *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+          * int(sizes(2), kind=MPI_OFFSET_KIND) &
+          * int(sizes(3), kind=MPI_OFFSET_KIND) &
+          * int(mytype_bytes, kind=MPI_OFFSET_KIND)
    if (data_type == complex_type) disp = disp + int(sizes(1), kind=MPI_OFFSET_KIND) &
-                                         *int(sizes(2), kind=MPI_OFFSET_KIND) &
-                                         *int(sizes(3), kind=MPI_OFFSET_KIND) &
-                                         *int(mytype_bytes, kind=MPI_OFFSET_KIND)
+                                         * int(sizes(2), kind=MPI_OFFSET_KIND) &
+                                         * int(sizes(3), kind=MPI_OFFSET_KIND) &
+                                         * int(mytype_bytes, kind=MPI_OFFSET_KIND)
 end associate
 
 associate (vnm => varname) ! Silence unused dummy argument

--- a/src/transpose_x_to_y.f90
+++ b/src/transpose_x_to_y.f90
@@ -274,14 +274,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%x1count + 1
+        pos = m * decomp%x1count + 1
 #else
         pos = decomp%x1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2 * n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -326,14 +326,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%x1count + 1
+        pos = m * decomp%x1count + 1
 #else
         pos = decomp%x1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), i2 - i1 + 1, in(i1, 1, 1), n1, i2 - i1 + 1, n2 * n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -378,14 +378,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y1count + 1
+        pos = m * decomp%y1count + 1
 #else
         pos = decomp%y1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(1, i1, 1), n1 * n2, in(pos), n1 * (i2 - i1 + 1), n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -430,14 +430,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y1count + 1
+        pos = m * decomp%y1count + 1
 #else
         pos = decomp%y1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(1, i1, 1), n1 * n2, in(pos), n1 * (i2 - i1 + 1), n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else

--- a/src/transpose_y_to_x.f90
+++ b/src/transpose_y_to_x.f90
@@ -274,14 +274,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y1count + 1
+        pos = m * decomp%y1count + 1
 #else
         pos = decomp%y1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), n1 * (i2 - i1 + 1), in(1, i1, 1), n1 * n2, n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -326,14 +326,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y1count + 1
+        pos = m * decomp%y1count + 1
 #else
         pos = decomp%y1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), n1 * (i2 - i1 + 1), in(1, i1, 1), n1 * n2, n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -378,14 +378,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%x1count + 1
+        pos = m * decomp%x1count + 1
 #else
         pos = decomp%x1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2 * n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -430,14 +430,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%x1count + 1
+        pos = m * decomp%x1count + 1
 #else
         pos = decomp%x1disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2*n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(i1, 1, 1), n1, in(pos), i2 - i1 + 1, i2 - i1 + 1, n2 * n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else

--- a/src/transpose_y_to_z.f90
+++ b/src/transpose_y_to_z.f90
@@ -136,7 +136,7 @@
 #if defined(_GPU)
      !If one of the array in cuda call is not device we need to add acc host_data
      !$acc host_data use_device(dst)
-     istat = cudaMemcpy(dst, work2_r_d, d1*d2*d3, cudaMemcpyDeviceToDevice)
+     istat = cudaMemcpy(dst, work2_r_d, d1 * d2 * d3, cudaMemcpyDeviceToDevice)
      !$acc end host_data
      if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
@@ -274,7 +274,7 @@
 
 #if defined(_GPU)
      !$acc host_data use_device(dst)
-     istat = cudaMemcpy(dst, work2_c_d, d1*d2*d3, cudaMemcpyDeviceToDevice)
+     istat = cudaMemcpy(dst, work2_c_d, d1 * d2 * d3, cudaMemcpyDeviceToDevice)
      !$acc end host_data
      if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
@@ -315,14 +315,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y2count + 1
+        pos = m * decomp%y2count + 1
 #else
         pos = decomp%y2disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), n1 * (i2 - i1 + 1), in(1, i1, 1), n1 * n2, n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -367,14 +367,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y2count + 1
+        pos = m * decomp%y2count + 1
 #else
         pos = decomp%y2disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(in)
-        istat = cudaMemcpy2D(out(pos), n1*(i2 - i1 + 1), in(1, i1, 1), n1*n2, n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(pos), n1 * (i2 - i1 + 1), in(1, i1, 1), n1 * n2, n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -415,7 +415,7 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%z2count + 1
+        pos = m * decomp%z2count + 1
 #else
         pos = decomp%z2disp(m) + 1
 #endif
@@ -456,7 +456,7 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%z2count + 1
+        pos = m * decomp%z2count + 1
 #else
         pos = decomp%z2disp(m) + 1
 #endif

--- a/src/transpose_z_to_y.f90
+++ b/src/transpose_z_to_y.f90
@@ -87,7 +87,7 @@
 
 #if defined(_GPU)
      !$acc host_data use_device(src)
-     istat = cudaMemcpy(work1_r_d, src, s1*s2*s3, cudaMemcpyDeviceToDevice)
+     istat = cudaMemcpy(work1_r_d, src, s1 * s2 * s3, cudaMemcpyDeviceToDevice)
      !$acc end host_data
      if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
@@ -223,7 +223,7 @@
 
 #if defined(_GPU)
      !$acc host_data use_device(src)
-     istat = cudaMemcpy(work1_c_d, src, s1*s2*s3, cudaMemcpyDeviceToDevice)
+     istat = cudaMemcpy(work1_c_d, src, s1 * s2 * s3, cudaMemcpyDeviceToDevice)
      !$acc end host_data
      if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #endif
@@ -310,7 +310,7 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%z2count + 1
+        pos = m * decomp%z2count + 1
 #else
         pos = decomp%z2disp(m) + 1
 #endif
@@ -351,7 +351,7 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%z2count + 1
+        pos = m * decomp%z2count + 1
 #else
         pos = decomp%z2disp(m) + 1
 #endif
@@ -396,14 +396,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y2count + 1
+        pos = m * decomp%y2count + 1
 #else
         pos = decomp%y2disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(1, i1, 1), n1 * n2, in(pos), n1 * (i2 - i1 + 1), n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else
@@ -449,14 +449,14 @@
         end if
 
 #ifdef EVEN
-        pos = m*decomp%y2count + 1
+        pos = m * decomp%y2count + 1
 #else
         pos = decomp%y2disp(m) + 1
 #endif
 
 #if defined(_GPU)
         !$acc host_data use_device(out)
-        istat = cudaMemcpy2D(out(1, i1, 1), n1*n2, in(pos), n1*(i2 - i1 + 1), n1*(i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
+        istat = cudaMemcpy2D(out(1, i1, 1), n1 * n2, in(pos), n1 * (i2 - i1 + 1), n1 * (i2 - i1 + 1), n3, cudaMemcpyDeviceToDevice)
         !$acc end host_data
         if (istat /= 0) call decomp_2d_abort(__FILE__, __LINE__, istat, "cudaMemcpy2D")
 #else


### PR DESCRIPTION
This ensures multiplication/division operators also get whitespace