### PR TITLE
401 issue in halo operations with periodicity

### DIFF
--- a/src/halo_exchange_x_body.f90
+++ b/src/halo_exchange_x_body.f90
@@ -17,44 +17,53 @@
   ! all data in local memory already, no halo exchange
 
   ! *** north/south ***
-  tag_s = coord(1)
-  if (coord(1) == dims(1) - 1 .AND. periodic_y) then
-     tag_n = 0
+  if ((dims(1) == 1) .and. periodic_y) then
+     ! No need for MPI communication
+
+     !$acc kernels default(present)
+     arr(:, halo_extents%ys:halo_extents%ys + levels(2) - 1, :) = arr(:, halo_extents%ye - 2 * levels(2) + 1:halo_extents%ye - levels(2), :)
+     arr(:, halo_extents%ye - levels(2) + 1:halo_extents%ye, :) = arr(:, halo_extents%ys + levels(2):halo_extents%ys + 2 * levels(2) - 1, :)
+     !$acc end kernels
   else
-     tag_n = coord(1) + 1
+     tag_s = coord(1)
+     if (coord(1) == dims(1) - 1 .AND. periodic_y) then
+        tag_n = 0
+     else
+        tag_n = coord(1) + 1
+     end if
+     icount = halo_extents%buffer_count(2)
+     ilength = halo_extents%buffer_length(2)
+     ijump = halo_extents%buffer_stride(2)
+     call MPI_TYPE_VECTOR(icount, ilength, ijump, &
+          data_type, halo12, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
+     call MPI_TYPE_COMMIT(halo12, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
+     ! receive from south
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo12, &
+          neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from north
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo12, &
+          neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to south
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo12, &
+          neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to north
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo12, &
+          neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
+     call MPI_TYPE_FREE(halo12, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
   end if
-  icount = halo_extents%buffer_count(2)
-  ilength = halo_extents%buffer_length(2)
-  ijump = halo_extents%buffer_stride(2)
-  call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-                       data_type, halo12, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
-  call MPI_TYPE_COMMIT(halo12, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
-  ! receive from south
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo12, &
-                 neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from north
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo12, &
-                 neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to south
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo12, &
-                  neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to north
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo12, &
-                  neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
-  call MPI_TYPE_FREE(halo12, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in Y'
@@ -68,35 +77,44 @@
   ! no need to define derived data type as data on xy-planes
   ! all contiguous in memory, which can be sent/received using
   ! MPI directly
-  tag_b = coord(2)
-  if (coord(2) == dims(2) - 1 .AND. periodic_z) then
-     tag_t = 0
+  if ((dims(2) == 1) .and. periodic_z) then
+     ! Non need for MPI communication
+
+     !$acc kernels default(present)
+     arr(:, :, halo_extents%zs:halo_extents%zs + levels(3) - 1) = arr(:, :, halo_extents%ze - 2 * levels(3) + 1:halo_extents%ze - levels(3))
+     arr(:, :, halo_extents%ze - levels(3) + 1:halo_extents%ze) = arr(:, :, halo_extents%zs + levels(3):halo_extents%zs + 2 * levels(3) - 1)
+     !$acc end kernels
   else
-     tag_t = coord(2) + 1
+     tag_b = coord(2)
+     if (coord(2) == dims(2) - 1 .AND. periodic_z) then
+        tag_t = 0
+     else
+        tag_t = coord(2) + 1
+     end if
+     ilength = halo_extents%buffer_length(3)
+     ! receive from bottom
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
+          neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from top
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
+          neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to bottom
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
+          neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to top
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
+          neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
   end if
-  ilength = halo_extents%buffer_length(3)
-  ! receive from bottom
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
-                 neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from top
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
-                 neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to bottom
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
-                  neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to top
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
-                  neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in Z'

--- a/src/halo_exchange_x_body.f90
+++ b/src/halo_exchange_x_body.f90
@@ -35,29 +35,29 @@
      ilength = halo_extents%buffer_length(2)
      ijump = halo_extents%buffer_stride(2)
      call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-          data_type, halo12, ierror)
+                          data_type, halo12, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
      call MPI_TYPE_COMMIT(halo12, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
      ! receive from south
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo12, &
-          neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
-          requests(1), ierror)
+                    neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from north
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo12, &
-          neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
-          requests(2), ierror)
+                    neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to south
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo12, &
-          neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
-          requests(3), ierror)
+                     neighbour(1, 4), tag_s, DECOMP_2D_COMM_CART_X, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to north
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo12, &
-          neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
-          requests(4), ierror)
+                     neighbour(1, 3), tag_n, DECOMP_2D_COMM_CART_X, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
@@ -94,23 +94,23 @@
      ilength = halo_extents%buffer_length(3)
      ! receive from bottom
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
-          neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
-          requests(1), ierror)
+                    neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from top
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
-          neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
-          requests(2), ierror)
+                    neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to bottom
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
-          neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
-          requests(3), ierror)
+                     neighbour(1, 6), tag_b, DECOMP_2D_COMM_CART_X, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to top
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
-          neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
-          requests(4), ierror)
+                     neighbour(1, 5), tag_t, DECOMP_2D_COMM_CART_X, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")

--- a/src/halo_exchange_y_body.f90
+++ b/src/halo_exchange_y_body.f90
@@ -32,29 +32,29 @@
      ilength = halo_extents%buffer_length(1)
      ijump = halo_extents%buffer_stride(1)
      call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-          data_type, halo21, ierror)
+                          data_type, halo21, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
      call MPI_TYPE_COMMIT(halo21, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
      ! receive from west
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo21, &
-          neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
-          requests(1), ierror)
+                    neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from east
      call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
-          neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
-          requests(2), ierror)
+                    neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to west
      call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo21, &
-          neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
-          requests(3), ierror)
+                     neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to east
      call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
-          neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
-          requests(4), ierror)
+                     neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
@@ -93,23 +93,23 @@
      ilength = halo_extents%buffer_length(3)
      ! receive from bottom
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
-          neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
-          requests(1), ierror)
+                    neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from top
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
-          neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
-          requests(2), ierror)
+                    neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to bottom
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
-          neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
-          requests(3), ierror)
+                     neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to top
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
-          neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
-          requests(4), ierror)
+                     neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")

--- a/src/halo_exchange_y_body.f90
+++ b/src/halo_exchange_y_body.f90
@@ -14,44 +14,53 @@
 #endif
 
   ! *** east/west ***
-  tag_w = coord(1)
-  if (coord(1) == dims(1) - 1 .AND. periodic_x) then
-     tag_e = 0
+  if ((dims(1) == 1) .and. periodic_x) then
+     ! Non need for MPI communication
+
+     !$acc kernels default(present)
+     arr(halo_extents%xs:halo_extents%xs + levels(1) - 1, :, :) = arr(halo_extents%xe - 2 * levels(1) + 1:halo_extents%xe - levels(1), :, :)
+     arr(halo_extents%xe - levels(1) + 1:halo_extents%xe, :, :) = arr(halo_extents%xs + levels(1):halo_extents%xs + 2 * levels(1) - 1, :, :)
+     !$acc end kernels
   else
-     tag_e = coord(1) + 1
+     tag_w = coord(1)
+     if (coord(1) == dims(1) - 1 .AND. periodic_x) then
+        tag_e = 0
+     else
+        tag_e = coord(1) + 1
+     end if
+     icount = halo_extents%buffer_count(1)
+     ilength = halo_extents%buffer_length(1)
+     ijump = halo_extents%buffer_stride(1)
+     call MPI_TYPE_VECTOR(icount, ilength, ijump, &
+          data_type, halo21, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
+     call MPI_TYPE_COMMIT(halo21, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
+     ! receive from west
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo21, &
+          neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from east
+     call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
+          neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to west
+     call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo21, &
+          neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to east
+     call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
+          neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
+     call MPI_TYPE_FREE(halo21, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
   end if
-  icount = halo_extents%buffer_count(1)
-  ilength = halo_extents%buffer_length(1)
-  ijump = halo_extents%buffer_stride(1)
-  call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-                       data_type, halo21, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
-  call MPI_TYPE_COMMIT(halo21, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
-  ! receive from west
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo21, &
-                 neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from east
-  call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
-                 neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to west
-  call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo21, &
-                  neighbour(2, 2), tag_w, DECOMP_2D_COMM_CART_Y, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to east
-  call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo21, &
-                  neighbour(2, 1), tag_e, DECOMP_2D_COMM_CART_Y, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
-  call MPI_TYPE_FREE(halo21, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in X'
@@ -68,35 +77,43 @@
   ! no need to define derived data type as data on xy-planes
   ! all contiguous in memory, which can be sent/received using
   ! MPI directly
-  tag_b = coord(2)
-  if (coord(2) == dims(2) - 1 .AND. periodic_z) then
-     tag_t = 0
+  if ((dims(2) == 1) .and. periodic_z) then
+     ! Non need for MPI communication
+     !$acc kernels default(present)
+     arr(:, :, halo_extents%zs:halo_extents%zs + levels(3) - 1) = arr(:, :, halo_extents%ze - 2 * levels(3) + 1:halo_extents%ze - levels(3))
+     arr(:, :, halo_extents%ze - levels(3) + 1:halo_extents%ze) = arr(:, :, halo_extents%zs + levels(3):halo_extents%zs + 2 * levels(3) - 1)
+     !$acc end kernels
   else
-     tag_t = coord(2) + 1
+     tag_b = coord(2)
+     if (coord(2) == dims(2) - 1 .AND. periodic_z) then
+        tag_t = 0
+     else
+        tag_t = coord(2) + 1
+     end if
+     ilength = halo_extents%buffer_length(3)
+     ! receive from bottom
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
+          neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from top
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
+          neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to bottom
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
+          neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to top
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
+          neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
   end if
-  ilength = halo_extents%buffer_length(3)
-  ! receive from bottom
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), ilength, data_type, &
-                 neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from top
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) + 1), ilength, data_type, &
-                 neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to bottom
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs + levels(3)), ilength, data_type, &
-                  neighbour(2, 6), tag_b, DECOMP_2D_COMM_CART_Y, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to top
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys, halo_extents%ze - levels(3) - levels(3) + 1), ilength, data_type, &
-                  neighbour(2, 5), tag_t, DECOMP_2D_COMM_CART_Y, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in Z'

--- a/src/halo_exchange_z_body.f90
+++ b/src/halo_exchange_z_body.f90
@@ -13,44 +13,52 @@
   end if
 #endif
   ! *** east/west ***
-  tag_w = coord(1)
-  if (coord(1) == dims(1) - 1 .AND. periodic_x) then
-     tag_e = 0
+  if ((dims(1) == 1) .and. periodic_x) then
+     ! Non need for MPI communication
+     !$acc kernels default(present)
+     arr(halo_extents%xs:halo_extents%xs + levels(1) - 1, :, :) = arr(halo_extents%xe - 2 * levels(1) + 1:halo_extents%xe - levels(1), :, :)
+     arr(halo_extents%xe - levels(1) + 1:halo_extents%xe, :, :) = arr(halo_extents%xs + levels(1):halo_extents%xs + 2 * levels(1) - 1, :, :)
+     !$acc end kernels
   else
-     tag_e = coord(1) + 1
+     tag_w = coord(1)
+     if (coord(1) == dims(1) - 1 .AND. periodic_x) then
+        tag_e = 0
+     else
+        tag_e = coord(1) + 1
+     end if
+     icount = halo_extents%buffer_count(1)
+     ilength = halo_extents%buffer_length(1)
+     ijump = halo_extents%buffer_stride(1)
+     call MPI_TYPE_VECTOR(icount, ilength, ijump, &
+          data_type, halo31, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
+     call MPI_TYPE_COMMIT(halo31, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
+     ! receive from west
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo31, &
+          neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from east
+     call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
+          neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to west
+     call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo31, &
+          neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to east
+     call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
+          neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
+     call MPI_TYPE_FREE(halo31, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
   end if
-  icount = halo_extents%buffer_count(1)
-  ilength = halo_extents%buffer_length(1)
-  ijump = halo_extents%buffer_stride(1)
-  call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-                       data_type, halo31, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
-  call MPI_TYPE_COMMIT(halo31, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
-  ! receive from west
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo31, &
-                 neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from east
-  call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
-                 neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to west
-  call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo31, &
-                  neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to east
-  call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
-                  neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
-  call MPI_TYPE_FREE(halo31, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in X'
@@ -61,44 +69,52 @@
 #endif
 
   ! *** north/south ***
-  tag_s = coord(2)
-  if (coord(2) == dims(2) - 1 .AND. periodic_y) then
-     tag_n = 0
+  if ((dims(2) == 1) .and. periodic_y) then
+     ! Non need for MPI communication
+     !$acc kernels default(present)
+     arr(:, halo_extents%ys:halo_extents%ys + levels(2) - 1, :) = arr(:, halo_extents%ye - 2 * levels(2) + 1:halo_extents%ye - levels(2), :)
+     arr(:, halo_extents%ye - levels(2) + 1:halo_extents%ye, :) = arr(:, halo_extents%ys + levels(2):halo_extents%ys + 2 * levels(2) - 1, :)
+     !$acc end kernels
   else
-     tag_n = coord(2) + 1
+     tag_s = coord(2)
+     if (coord(2) == dims(2) - 1 .AND. periodic_y) then
+        tag_n = 0
+     else
+        tag_n = coord(2) + 1
+     end if
+     icount = halo_extents%buffer_count(2)
+     ilength = halo_extents%buffer_length(2)
+     ijump = halo_extents%buffer_stride(2)
+     call MPI_TYPE_VECTOR(icount, ilength, ijump, &
+          data_type, halo32, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
+     call MPI_TYPE_COMMIT(halo32, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
+     ! receive from south
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo32, &
+          neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
+          requests(1), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! receive from north
+     call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo32, &
+          neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
+          requests(2), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
+     ! send to south
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo32, &
+          neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
+          requests(3), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     ! send to north
+     call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo32, &
+          neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
+          requests(4), ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
+     call MPI_WAITALL(4, requests, status, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
+     call MPI_TYPE_FREE(halo32, ierror)
+     if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
   end if
-  icount = halo_extents%buffer_count(2)
-  ilength = halo_extents%buffer_length(2)
-  ijump = halo_extents%buffer_stride(2)
-  call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-                       data_type, halo32, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
-  call MPI_TYPE_COMMIT(halo32, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
-  ! receive from south
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo32, &
-                 neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
-                 requests(1), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! receive from north
-  call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo32, &
-                 neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
-                 requests(2), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
-  ! send to south
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo32, &
-                  neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
-                  requests(3), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  ! send to north
-  call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo32, &
-                  neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
-                  requests(4), ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
-  call MPI_WAITALL(4, requests, status, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
-  call MPI_TYPE_FREE(halo32, ierror)
-  if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_FREE")
 #ifdef HALO_DEBUG
   if (nrank == 0) then
      write (*, *) 'After exchange in Y'

--- a/src/halo_exchange_z_body.f90
+++ b/src/halo_exchange_z_body.f90
@@ -30,29 +30,29 @@
      ilength = halo_extents%buffer_length(1)
      ijump = halo_extents%buffer_stride(1)
      call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-          data_type, halo31, ierror)
+                          data_type, halo31, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
      call MPI_TYPE_COMMIT(halo31, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
      ! receive from west
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo31, &
-          neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
-          requests(1), ierror)
+                    neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from east
      call MPI_IRECV(arr(halo_extents%xe - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
-          neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
-          requests(2), ierror)
+                    neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to west
      call MPI_ISSEND(arr(halo_extents%xs + levels(1), halo_extents%ys, halo_extents%zs), 1, halo31, &
-          neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
-          requests(3), ierror)
+                     neighbour(3, 2), tag_w, DECOMP_2D_COMM_CART_Z, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to east
      call MPI_ISSEND(arr(halo_extents%xe - levels(1) - levels(1) + 1, halo_extents%ys, halo_extents%zs), 1, halo31, &
-          neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
-          requests(4), ierror)
+                     neighbour(3, 1), tag_e, DECOMP_2D_COMM_CART_Z, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")
@@ -86,29 +86,29 @@
      ilength = halo_extents%buffer_length(2)
      ijump = halo_extents%buffer_stride(2)
      call MPI_TYPE_VECTOR(icount, ilength, ijump, &
-          data_type, halo32, ierror)
+                          data_type, halo32, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_VECTOR")
      call MPI_TYPE_COMMIT(halo32, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_TYPE_COMMIT")
      ! receive from south
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ys, halo_extents%zs), 1, halo32, &
-          neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
-          requests(1), ierror)
+                    neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
+                    requests(1), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! receive from north
      call MPI_IRECV(arr(halo_extents%xs, halo_extents%ye - levels(2) + 1, halo_extents%zs), 1, halo32, &
-          neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
-          requests(2), ierror)
+                    neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
+                    requests(2), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_IRECV")
      ! send to south
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ys + levels(2), halo_extents%zs), 1, halo32, &
-          neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
-          requests(3), ierror)
+                     neighbour(3, 4), tag_s, DECOMP_2D_COMM_CART_Z, &
+                     requests(3), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      ! send to north
      call MPI_ISSEND(arr(halo_extents%xs, halo_extents%ye - levels(2) - levels(2) + 1, halo_extents%zs), 1, halo32, &
-          neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
-          requests(4), ierror)
+                     neighbour(3, 3), tag_n, DECOMP_2D_COMM_CART_Z, &
+                     requests(4), ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_ISSEND")
      call MPI_WAITALL(4, requests, status, ierror)
      if (ierror /= 0) call decomp_2d_abort(__FILE__, __LINE__, ierror, "MPI_WAITALL")


### PR DESCRIPTION
This ports the fixes for halos in periodic problems when there is one rank in the periodic direction(s) originally implemented in #401 for the `main` branch.