### PR TITLE
Add check for new CrayFTN versions

### DIFF
--- a/cmake/compilers/D2D_flags_cray.cmake
+++ b/cmake/compilers/D2D_flags_cray.cmake
@@ -3,3 +3,9 @@
 set(D2D_FFLAGS "-eF -g -N 1023 -M878 -M296")
 set(D2D_FFLAGS_RELEASE "-O3")
 set(D2D_FFLAGS_DEBUG   "-O0 -g")
+
+if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 19.0.0)
+  message(STATUS "Setting submodules for new CrayFTN")
+  set(CMAKE_Fortran_SUBMODULE_SEP ".")
+  set(CMAKE_Fortran_SUBMODULE_EXT ".smod")
+endif()


### PR DESCRIPTION
Newer CrayFTN releases have changed the submodule naming scheme. As CMake does not yet support this, we need to tell it through our cmake scripts.