### PR TITLE
Update the memory pool to avoid Cray compiler warnings

### DIFF
--- a/src/mem_pool.f90
+++ b/src/mem_pool.f90
@@ -324,6 +324,7 @@ contains
          if (product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 1) /= mem_pool_none) then
+         allocate(shp(3))
          shp = self%shapes(:, 1)
       else
          call decomp_2d_abort(__FILE__, __LINE__, 2, "No shape available")
@@ -360,6 +361,7 @@ contains
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 2) /= mem_pool_none) then
+         allocate(shp(3))
          shp = self%shapes(:, 2)
       else
          call decomp_2d_abort(__FILE__, __LINE__, 2, "No shape available")
@@ -396,6 +398,7 @@ contains
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 3) /= mem_pool_none) then
+         allocate(shp(3))
          shp = self%shapes(:, 3)
       else
          call decomp_2d_abort(__FILE__, __LINE__, 2, "No shape available")
@@ -432,6 +435,7 @@ contains
          if (4_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 4) /= mem_pool_none) then
+         allocate(shp(3))
          shp = self%shapes(:, 4)
       else
          call decomp_2d_abort(__FILE__, __LINE__, 2, "No shape available")

--- a/src/mem_pool.f90
+++ b/src/mem_pool.f90
@@ -319,7 +319,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
-         shp = shape
+         shp = int(shape, kind=c_size_t)
          if (product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 1) /= mem_pool_none) then
@@ -354,7 +354,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
-         shp = shape
+         shp = int(shape, kind=c_size_t)
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 2) /= mem_pool_none) then
@@ -389,7 +389,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
-         shp = shape
+         shp = int(shape, kind=c_size_t)
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 3) /= mem_pool_none) then
@@ -424,7 +424,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
-         shp = shape
+         shp = int(shape, kind=c_size_t)
          if (4_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
       else if (self%shapes(1, 4) /= mem_pool_none) then

--- a/src/mem_pool.f90
+++ b/src/mem_pool.f90
@@ -319,6 +319,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
+         allocate(shp(size(shape)))
          shp = int(shape, kind=c_size_t)
          if (product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
@@ -354,6 +355,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
+         allocate(shp(size(shape)))
          shp = int(shape, kind=c_size_t)
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
@@ -389,6 +391,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
+         allocate(shp(size(shape)))
          shp = int(shape, kind=c_size_t)
          if (2_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")
@@ -424,6 +427,7 @@ contains
 
       ! Use the provided shape, or the default one
       if (present(shape)) then
+         allocate(shp(size(shape)))
          shp = int(shape, kind=c_size_t)
          if (4_c_size_t * product(int(shp, c_size_t)) > self%size) &
             call decomp_2d_abort(__FILE__, __LINE__, 2, "Invalid shape")


### PR DESCRIPTION
Compilation warnings reported by C.M. using Cray Fortran Version 16.0.1

Draft PR will be converted to regular PR when we have confirmation the warnings are gone